### PR TITLE
Initial review: add tests, documentation, and safe-by-default --confirm flag

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+export CONDA_DIR="/home/andy/miniconda3"
+source "$CONDA_DIR/etc/profile.d/conda.sh"
 layout conda py312

--- a/.github/additional-copilot-instructions.md
+++ b/.github/additional-copilot-instructions.md
@@ -62,11 +62,12 @@ browser and WhatsApp login. Restrict unit tests to pure-Python helpers.
 selectors there first when WhatsApp changes its UI — never scatter selector
 strings across other modules.
 
-### Dry-run flag
+### Confirm / dry-run flag
 
-The CLI exposes `--dry-run` (not `--confirm`) because it aligns with the
-WhatsApp export context where "inspect without writing" is the expected safe
-default phrasing. The `dryRun` boolean is passed through `RuntimeConfig`.
+The CLI uses `--confirm` (safe-by-default pattern). When `--confirm` is **not** passed the
+tool runs in dry-run mode — it opens the browser and inspects polls but writes no files.
+Pass `--confirm` to execute the export. The `dryRun` boolean (`not args.confirm`) is stored
+in `RuntimeConfig` and threaded through to `AttendanceExporter`.
 
 ### Logging
 

--- a/.github/additional-copilot-instructions.md
+++ b/.github/additional-copilot-instructions.md
@@ -71,9 +71,9 @@ in `RuntimeConfig` and threaded through to `AttendanceExporter`.
 
 ### Logging
 
-The module falls back to `stdlib logging` when `organiseMyProjects.logUtils` is
-not installed. New code should follow the same `try / except` pattern used in
-`whatsappAttendance.py` so the tool works stand-alone.
+Use `organiseMyProjects.logUtils` directly for centralized logging. Do not add
+new stdlib logging fallbacks in this repository; tests should stub the
+dependency when needed.
 
 ### Output files
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# app specifics
+output/
+
 __pycache__/
 logs/
 *.log

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,16 @@
+default_language_version:
+  python: python3
+
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 25.1.0
     hooks:
       - id: black
-        language: system
+
   - repo: local
     hooks:
       - id: gui-naming-linter
         name: GUI Naming Linter
-        entry: python tests/runLinter.py
-        language: system
+        entry: runLinter
+        language: python
         types: [python]

--- a/README.md
+++ b/README.md
@@ -35,11 +35,18 @@ python exportAttendance.py \
   --user-data-dir ~/.local/share/organiseMyFooty/profile
 ```
 
-For a safe first run (inspect without writing files):
+For a safe first run (inspect without writing files — default behaviour):
 
 ```bash
 cd src
-python exportAttendance.py --group "My Footy Group" --month 2026-03 --dry-run
+python exportAttendance.py --group "My Footy Group" --month 2026-03
+```
+
+To actually write the CSV exports, add `--confirm`:
+
+```bash
+cd src
+python exportAttendance.py --group "My Footy Group" --month 2026-03 --confirm
 ```
 
 ## CLI options
@@ -56,7 +63,7 @@ python exportAttendance.py --group "My Footy Group" --month 2026-03 --dry-run
 | `--include-no-votes` | Also collect "No" voters |
 | `--poll-title-filter` | Only process polls whose text contains this substring |
 | `--headless` | Run browser without showing a window |
-| `--dry-run` | Inspect and log without writing CSV exports |
+| `--confirm` | Write CSV exports; omit to run in safe dry-run mode (default) |
 
 ## Output files
 
@@ -76,7 +83,7 @@ black src/ tests/
 
 ## Notes
 
-- Uses WhatsApp Web browser automation; CSS selectors in `selectors.py` may need
+- Uses WhatsApp Web browser automation; CSS selectors in `whatsappSelectors.py` may need
   updating if WhatsApp changes its UI.
 - Reuses a persistent browser profile so you only need to log in once.
-- `--dry-run` runs the browser and inspects polls but writes no output files.
+- Without `--confirm`, the tool runs in dry-run mode and writes no output files.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python exportAttendance.py --group "My Footy Group" --month 2026-03 --confirm
 
 ```bash
 pip install -r dev-requirements.txt
-python -m pytest
+pytest
 black src/ tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ pip install -r requirements.txt
 playwright install chromium
 ```
 
+This project expects `organiseMyProjects.logUtils` to be available in the same
+Python environment for centralized logging.
+
 ## First-run login
 
 On the very first run the browser profile is empty, so WhatsApp Web will show
@@ -95,7 +98,7 @@ python exportAttendance.py --group "My Footy Group" --month 2026-03 --confirm
 
 ```bash
 pip install -r dev-requirements.txt
-pytest
+python -m pytest
 black src/ tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ pip install -r requirements.txt
 playwright install chromium
 ```
 
+## First-run login
+
+On the very first run the browser profile is empty, so WhatsApp Web will show
+a QR-code login screen inside the Playwright-controlled browser window.
+
+1. Run without `--headless` (the default) so the browser window is visible.
+2. Open WhatsApp on your phone → **Linked devices** → **Link a device**.
+3. Scan the QR code shown in the browser window.
+4. Wait for your chats to load, then the tool will continue automatically.
+
+The session is persisted in `--user-data-dir`, so you only need to do this
+once. If the default 120-second window is not enough to scan the code, pass
+a longer timeout:
+
+```bash
+python main.py --group "My Footy Group" --month 2026-03 --timeout-ms 300000
+```
+
 ## Usage
 
 Run from the `src/` directory (or add `src/` to `PYTHONPATH`):

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
-from ui.mainMenu import mainMenu
+from __future__ import annotations
 
+import sys
+from pathlib import Path
 
-def main():
-    print("Starting application...")
-    mainMenu()
+sys.path.insert(0, str(Path(__file__).parent / "src"))
 
+from exportAttendance import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-from exportAttendance import main  # noqa: E402
+from exportAttendance import main as run_app  # noqa: E402
 
 if __name__ == "__main__":
-    main()
+    run_app()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 python_files = test[!_]*.py
 python_functions = test*

--- a/src/exportAttendance.py
+++ b/src/exportAttendance.py
@@ -73,9 +73,9 @@ def buildParser() -> argparse.ArgumentParser:
         help="reserved for future checkpoint/resume logic",
     )
     parser.add_argument(
-        "--dry-run",
+        "--confirm",
         action="store_true",
-        help="inspect and log without writing CSV exports",
+        help="execute changes and write CSV exports (default is dry-run)",
     )
     return parser
 
@@ -96,7 +96,7 @@ def main() -> None:
         outputDir=outputDir,
         userDataDir=userDataDir,
         headless=args.headless,
-        dryRun=args.dry_run,
+        dryRun=not args.confirm,
         timeoutMs=args.timeout_ms,
         limitPolls=args.limit_polls,
         browserChannel=args.browser_channel,

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -278,7 +278,7 @@ class AttendanceExporter(DryRunMixin):
         deadline = time.time() + max(120, self.config.timeoutMs / 1000)
 
         while time.time() < deadline:
-            for selector in self.selectors.iterSearchSelectors():
+            for selector in self.selectors.iterReadySelectors():
                 try:
                     locator = page.locator(selector).first
                     if locator.is_visible(timeout=1000):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -9,7 +9,7 @@ import json
 import re
 import time
 
-# External runtime dependency; tests stub this module in tests/conftest.py.
+# Private alias used by the local getLogger wrapper; tests stub this dependency.
 from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore[import-not-found]
 
 from attendanceConfig import RuntimeConfig, writeCsv

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -9,7 +9,8 @@ import json
 import re
 import time
 
-from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore
+# External runtime dependency; tests stub this module in tests/conftest.py.
+from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore[import-not-found]
 
 from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -413,7 +413,6 @@ class AttendanceExporter(DryRunMixin):
                 processed = index + 1
                 if count > POLL_SCAN_PROGRESS_LOG_INTERVAL and (
                     processed % POLL_SCAN_PROGRESS_LOG_INTERVAL == 0
-                    or processed == count
                 ):
                     self.logger.info(
                         "%sprocessed %s/%s poll candidate(s) for selector '%s'",

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -12,6 +12,9 @@ import time
 from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors
 
+DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browser page.
+
+
 try:
     from organiseMyProjects.logUtils import getLogger  # type: ignore
 except Exception:  # pragma: no cover
@@ -179,7 +182,9 @@ class AttendanceExporter(DryRunMixin):
             )
             try:
                 page = browserContext.new_page()
-                self.logger.info("%snavigating to %s", self.prefix, self.selectors.webUrl)
+                self.logger.info(
+                    "%snavigating to %s", self.prefix, self.selectors.webUrl
+                )
                 page.goto(self.selectors.webUrl)
                 self.logger.info("%spage loaded: %s", self.prefix, page.url)
                 self.waitForWhatsAppReady(page)
@@ -237,7 +242,16 @@ class AttendanceExporter(DryRunMixin):
                             )
                             continue
 
-                    dialog = self.waitForDialog(page)
+                    try:
+                        dialog = self.waitForDialog(page)
+                    except TimeoutError:
+                        self.logger.warning(
+                            "%sunable to locate votes dialog for poll %s; skipping",
+                            self.prefix,
+                            index,
+                        )
+                        self.closeDialog(page, dialog=None)
+                        continue
                     pollTitle = (
                         self.extractPollTitle(dialog, sourceText=sourceText)
                         or "unknown poll"
@@ -397,16 +411,32 @@ class AttendanceExporter(DryRunMixin):
         return pollLocators
 
     def waitForDialog(self, page):
-        for selector in self.selectors.iterDialogSelectors():
-            try:
-                dialog = page.locator(selector).last
-                dialog.wait_for(state="visible", timeout=self.config.timeoutMs)
-                self.logger.info(
-                    "%svotes dialog opened via selector: %s", self.prefix, selector
-                )
-                return dialog
-            except Exception:
-                continue
+        timeoutMs = max(self.config.timeoutMs, DIALOG_POLL_INTERVAL_MS)
+        deadline = time.time() + (timeoutMs / 1000)
+        selectors = tuple(self.selectors.iterDialogSelectors())
+
+        while time.time() < deadline:
+            remainingMs = int((deadline - time.time()) * 1000)
+            if remainingMs <= 0:
+                break
+            # Keep the overall deadline separate from the per-selector probe timeout so
+            # we can retry multiple selector candidates within the remaining time budget.
+            probeTimeoutMs = min(1000, remainingMs)
+            for selector in selectors:
+                try:
+                    dialog = page.locator(selector).last
+                    if dialog.is_visible(timeout=probeTimeoutMs):
+                        self.logger.info(
+                            "%svotes dialog opened via selector: %s",
+                            self.prefix,
+                            selector,
+                        )
+                        return dialog
+                except Exception:
+                    continue
+
+            page.wait_for_timeout(DIALOG_POLL_INTERVAL_MS)
+
         raise TimeoutError("unable to locate votes dialog")
 
     def extractPollTitle(self, dialog, sourceText: str = "") -> str:
@@ -499,7 +529,9 @@ class AttendanceExporter(DryRunMixin):
         return cleaned
 
     def closeDialog(self, page, dialog) -> None:
-        for selector in self.selectors.closeDialogCandidates:
+        for selector in (
+            self.selectors.closeDialogCandidates + self.selectors.backCandidates
+        ):
             try:
                 control = page.locator(selector).first
                 if control.is_visible(timeout=1000):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -16,7 +16,7 @@ from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors
 
 DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browser page.
-POLL_SCAN_PROGRESS_LOG_INTERVAL = 25
+POLL_PROGRESS_INTERVAL = 25
 
 
 def getLogger(name: str, dryRun: bool = False):  # type: ignore
@@ -411,8 +411,8 @@ class AttendanceExporter(DryRunMixin):
                     )
                 )
                 processed = index + 1
-                if count > POLL_SCAN_PROGRESS_LOG_INTERVAL and (
-                    processed % POLL_SCAN_PROGRESS_LOG_INTERVAL == 0
+                if count >= POLL_PROGRESS_INTERVAL and (
+                    processed % POLL_PROGRESS_INTERVAL == 0
                 ):
                     self.logger.info(
                         "%sprocessed %s/%s poll candidate(s) for selector '%s'",

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
@@ -39,7 +40,7 @@ def getLogger(name: str, dryRun: bool = False):  # type: ignore
     logger = logging.getLogger(name)
     if not logger.handlers:
         logger.setLevel(logging.INFO)
-        handler = logging.StreamHandler()
+        handler = logging.StreamHandler(sys.stdout)
         formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(handler)
@@ -53,6 +54,13 @@ class PollRecord:
     option: str
     voterName: str
     sourceHint: str
+
+
+@dataclass(frozen=True)
+class PollTarget:
+    selector: str
+    sourceText: str
+    messageTestId: str = ""
 
 
 class DryRunMixin:
@@ -211,7 +219,7 @@ class AttendanceExporter(DryRunMixin):
                     "%scandidate poll cards found: %s", self.prefix, len(pollLocators)
                 )
 
-                for index, locator in enumerate(pollLocators, start=1):
+                for index, pollTarget in enumerate(pollLocators, start=1):
                     if (
                         self.config.limitPolls is not None
                         and pollCount >= self.config.limitPolls
@@ -223,13 +231,7 @@ class AttendanceExporter(DryRunMixin):
                         )
                         break
 
-                    try:
-                        locator.scroll_into_view_if_needed(
-                            timeout=self.config.timeoutMs
-                        )
-                        sourceText = locator.inner_text(timeout=self.config.timeoutMs)
-                    except Exception:
-                        sourceText = ""
+                    sourceText = pollTarget.sourceText
 
                     if (
                         self.config.pollTitleFilter
@@ -245,17 +247,10 @@ class AttendanceExporter(DryRunMixin):
 
                     self.logger.info("%sopening poll %s", self.prefix, index)
                     try:
-                        locator.click(timeout=self.config.timeoutMs)
-                    except Exception:
-                        try:
-                            locator.get_by_text(
-                                self.selectors.viewVotesText, exact=False
-                            ).click(timeout=self.config.timeoutMs)
-                        except Exception as exc:
-                            self.logger.warning(
-                                "Unable to open poll votes dialog: %s", exc
-                            )
-                            continue
+                        self.openPollTarget(page, pollTarget)
+                    except Exception as exc:
+                        self.logger.warning("Unable to open poll votes dialog: %s", exc)
+                        continue
 
                     try:
                         dialog = self.waitForDialog(page)
@@ -396,8 +391,8 @@ class AttendanceExporter(DryRunMixin):
                     "%sscroll pass %s/%s", self.prefix, i + 1, scrollPasses
                 )
 
-    def findPollCards(self, page) -> list:
-        pollLocators: list = []
+    def findPollCards(self, page) -> list[PollTarget]:
+        pollLocators: list[PollTarget] = []
         seenKeys: set[str] = set()
 
         for selector in self.selectors.iterPollSelectors():
@@ -417,13 +412,69 @@ class AttendanceExporter(DryRunMixin):
                     text = item.inner_text(timeout=1000)
                 except Exception:
                     text = f"item-{index}"
-                key = f"{selector}|{text[:120]}"
+                messageTestId = self.extractMessageTestId(item)
+                key = f"{messageTestId or selector}|{text[:120]}"
                 if key in seenKeys:
                     continue
                 seenKeys.add(key)
-                pollLocators.append(item)
+                pollLocators.append(
+                    PollTarget(
+                        selector=selector,
+                        sourceText=text,
+                        messageTestId=messageTestId or "",
+                    )
+                )
 
         return pollLocators
+
+    def extractMessageTestId(self, locator) -> str:
+        try:
+            container = locator.locator(
+                'xpath=ancestor-or-self::*[starts-with(@data-testid, "conv-msg-")][1]'
+            ).first
+            return container.get_attribute("data-testid") or ""
+        except Exception:
+            return ""
+
+    def extractPollSummaryText(self, sourceText: str) -> str:
+        for line in sourceText.splitlines():
+            value = line.strip()
+            if value:
+                return value
+        return ""
+
+    def buildPollButtonSelector(self, pollTarget: PollTarget) -> str:
+        if pollTarget.messageTestId:
+            return (
+                f'[data-testid="{pollTarget.messageTestId}"] '
+                '[data-testid="poll-view-votes"]'
+            )
+        return pollTarget.selector
+
+    def openPollTarget(self, page, pollTarget: PollTarget) -> None:
+        candidateLocators = [
+            page.locator(self.buildPollButtonSelector(pollTarget)).first
+        ]
+        summaryText = self.extractPollSummaryText(pollTarget.sourceText)
+        if summaryText:
+            candidateLocators.append(
+                page.locator(pollTarget.selector).filter(has_text=summaryText).first
+            )
+        if pollTarget.selector != self.buildPollButtonSelector(pollTarget):
+            candidateLocators.append(page.locator(pollTarget.selector).first)
+
+        lastError: Exception | None = None
+        for locator in candidateLocators:
+            try:
+                locator.scroll_into_view_if_needed(timeout=self.config.timeoutMs)
+                locator.click(timeout=self.config.timeoutMs)
+                return
+            except Exception as exc:
+                lastError = exc
+
+        if lastError is not None:
+            raise lastError
+        raise RuntimeError("unable to open poll votes dialog")
 
     def waitForDialog(self, page):
         timeoutMs = max(self.config.timeoutMs, DIALOG_POLL_INTERVAL_MS)

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -16,6 +16,7 @@ from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors
 
 DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browser page.
+POLL_SCAN_PROGRESS_LOG_INTERVAL = 25
 
 
 def getLogger(name: str, dryRun: bool = False):  # type: ignore
@@ -410,7 +411,10 @@ class AttendanceExporter(DryRunMixin):
                     )
                 )
                 processed = index + 1
-                if count > 25 and (processed % 25 == 0 or processed == count):
+                if count > POLL_SCAN_PROGRESS_LOG_INTERVAL and (
+                    processed % POLL_SCAN_PROGRESS_LOG_INTERVAL == 0
+                    or processed == count
+                ):
                     self.logger.info(
                         "%sprocessed %s/%s poll candidate(s) for selector '%s'",
                         self.prefix,

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -157,6 +157,14 @@ class AttendanceExporter(DryRunMixin):
         records: list[PollRecord] = []
         pollCount = 0
 
+        self.logger.info(
+            "%slaunching browser (user_data_dir=%s, headless=%s, channel=%s)",
+            self.prefix,
+            self.config.userDataDir,
+            self.config.headless,
+            self.config.browserChannel or "default",
+        )
+
         with sync_playwright() as playwright:
             browserContext = playwright.chromium.launch_persistent_context(
                 user_data_dir=str(self.config.userDataDir),
@@ -166,7 +174,9 @@ class AttendanceExporter(DryRunMixin):
             )
             try:
                 page = browserContext.new_page()
+                self.logger.info("%snavigating to %s", self.prefix, self.selectors.webUrl)
                 page.goto(self.selectors.webUrl)
+                self.logger.info("%spage loaded: %s", self.prefix, page.url)
                 self.waitForWhatsAppReady(page)
                 self.openGroup(page, self.config.groupName)
                 self.scrollChatHistory(page)
@@ -243,6 +253,7 @@ class AttendanceExporter(DryRunMixin):
                             )
                         )
 
+                    noVoters: list[str] = []
                     if self.config.includeNoVotes:
                         noVoters = self.extractOptionVoters(
                             dialog, optionTexts=self.selectors.noOptionTexts
@@ -257,6 +268,15 @@ class AttendanceExporter(DryRunMixin):
                                     sourceHint=sourceText[:240],
                                 )
                             )
+
+                    self.logger.info(
+                        "%spoll %s: title=%r, yes=%s voter(s), no=%s voter(s)",
+                        self.prefix,
+                        index,
+                        pollTitle,
+                        len(yesVoters),
+                        len(noVoters),
+                    )
 
                     pollCount += 1
                     self.closeDialog(page, dialog)
@@ -276,8 +296,18 @@ class AttendanceExporter(DryRunMixin):
             self.prefix,
         )
         deadline = time.time() + max(120, self.config.timeoutMs / 1000)
+        startTime = time.time()
+        lastProgressLog = 0.0
 
         while time.time() < deadline:
+            elapsed = int(time.time() - startTime)
+            if elapsed - lastProgressLog >= 10:
+                self.logger.info(
+                    "%sstill waiting for whatsapp web (%ss elapsed)...",
+                    self.prefix,
+                    elapsed,
+                )
+                lastProgressLog = elapsed
             for selector in self.selectors.iterReadySelectors():
                 try:
                     locator = page.locator(selector).first
@@ -306,6 +336,11 @@ class AttendanceExporter(DryRunMixin):
                 searchBox.click(timeout=self.config.timeoutMs)
                 searchBox.fill("")
                 searchBox.type(groupName, delay=40)
+                self.logger.info(
+                    "%ssearch box ready (selector: %s), typed group name",
+                    self.prefix,
+                    selector,
+                )
                 break
             except Exception as exc:
                 lastError = exc
@@ -315,12 +350,17 @@ class AttendanceExporter(DryRunMixin):
 
         candidate = page.get_by_text(groupName, exact=True).first
         candidate.click(timeout=self.config.timeoutMs)
+        self.logger.info("%sgroup chat opened", self.prefix)
 
     def scrollChatHistory(self, page, scrollPasses: int = 12) -> None:
         self.logger.info("%sscrolling chat history to load older polls...", self.prefix)
-        for _ in range(scrollPasses):
+        for i in range(scrollPasses):
             page.mouse.wheel(0, -2000)
             page.wait_for_timeout(500)
+            if (i + 1) % 4 == 0 or i + 1 == scrollPasses:
+                self.logger.info(
+                    "%sscroll pass %s/%s", self.prefix, i + 1, scrollPasses
+                )
 
     def findPollCards(self, page) -> list:
         pollLocators: list = []
@@ -332,6 +372,10 @@ class AttendanceExporter(DryRunMixin):
                 count = locator.count()
             except Exception:
                 continue
+
+            self.logger.info(
+                "%spoll selector '%s' matched %s item(s)", self.prefix, selector, count
+            )
 
             for index in range(count):
                 item = locator.nth(index)
@@ -352,6 +396,9 @@ class AttendanceExporter(DryRunMixin):
             try:
                 dialog = page.locator(selector).last
                 dialog.wait_for(state="visible", timeout=self.config.timeoutMs)
+                self.logger.info(
+                    "%svotes dialog opened via selector: %s", self.prefix, selector
+                )
                 return dialog
             except Exception:
                 continue
@@ -453,12 +500,16 @@ class AttendanceExporter(DryRunMixin):
                 if control.is_visible(timeout=1000):
                     control.click(timeout=self.config.timeoutMs)
                     page.wait_for_timeout(400)
+                    self.logger.info(
+                        "%sclosed dialog via selector: %s", self.prefix, selector
+                    )
                     return
             except Exception:
                 continue
 
         page.keyboard.press("Escape")
         page.wait_for_timeout(400)
+        self.logger.info("%sclosed dialog via Escape key", self.prefix)
 
     def deduplicateRecords(self, records: list[PollRecord]) -> list[PollRecord]:
         output: list[PollRecord] = []
@@ -474,4 +525,7 @@ class AttendanceExporter(DryRunMixin):
                 continue
             seen.add(key)
             output.append(record)
+        self.logger.info(
+            "%sdeduplication: %s → %s records", self.prefix, len(records), len(output)
+        )
         return output

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-import sys
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
@@ -11,40 +9,17 @@ import json
 import re
 import time
 
+from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore
+
 from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors
 
 DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browser page.
 
 
-try:
-    from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore
-except Exception:  # pragma: no cover
-    _logUtilsGetLogger = None
-
-
 def getLogger(name: str, dryRun: bool = False):  # type: ignore
-    if _logUtilsGetLogger is not None:
-        # Support both the richer organiseMyProjects logger signature and simpler
-        # variants so console logging still works across installed versions.
-        for kwargs in (
-            {"includeConsole": True, "dryRun": dryRun},
-            {"includeConsole": True},
-            {},
-        ):
-            try:
-                return _logUtilsGetLogger(name, **kwargs)
-            except TypeError:
-                continue
-
-    logger = logging.getLogger(name)
-    if not logger.handlers:
-        logger.setLevel(logging.INFO)
-        handler = logging.StreamHandler(sys.stdout)
-        formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-    return logger
+    """Return the project logger with console output enabled."""
+    return _logUtilsGetLogger(name, includeConsole=True, dryRun=dryRun)
 
 
 @dataclass(frozen=True)

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -9,7 +9,7 @@ import json
 import re
 import time
 
-# Private alias used by the local getLogger wrapper; tests stub this dependency.
+# Private alias for logUtils.getLogger; kept at module scope so tests can stub it.
 from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore[import-not-found]
 
 from attendanceConfig import RuntimeConfig, writeCsv

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -1,27 +1,33 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from datetime import datetime
+from collections import OrderedDict, defaultdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Optional, Iterable
+from typing import Iterable, Optional
 import csv
 import json
 import re
 import time
 
-# Private alias for logUtils.getLogger; kept at module scope so tests can stub it.
-from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore[import-not-found]
-
 from attendanceConfig import RuntimeConfig, writeCsv
 from whatsappSelectors import DEFAULT_SELECTORS, WhatsAppSelectors
 
-DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browser page.
-POLL_PROGRESS_INTERVAL = 25
+try:
+    from organiseMyProjects.logUtils import getLogger  # type: ignore
+except Exception:  # pragma: no cover
+    import logging
 
-
-def getLogger(name: str, dryRun: bool = False):  # type: ignore
-    """Return the project logger with console output enabled."""
-    return _logUtilsGetLogger(name, includeConsole=True, dryRun=dryRun)
+    def getLogger(name: str):  # type: ignore
+        logger = logging.getLogger(name)
+        if not logger.handlers:
+            logger.setLevel(logging.INFO)
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s %(levelname)s %(name)s: %(message)s"
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+        return logger
 
 
 @dataclass(frozen=True)
@@ -34,47 +40,64 @@ class PollRecord:
 
 
 @dataclass(frozen=True)
-class PollTarget:
-    """Stable poll target data used to refind a vote button after the UI changes."""
+class PollSession:
+    pollKey: str
+    pollTitle: str
+    weekNumber: int
+    sessionName: str
 
-    selector: str
-    sourceText: str
-    messageTestId: str = ""
+
+class DryRunMixin:
+    @property
+    def prefix(self) -> str:
+        return "...[] " if self.config.dryRun else "..."
 
 
-class AttendanceExporter:
+class AttendanceExporter(DryRunMixin):
     def __init__(
         self, config: RuntimeConfig, selectors: WhatsAppSelectors | None = None
     ):
         self.config = config
         self.selectors = selectors or DEFAULT_SELECTORS
-        self.logger = getLogger(
-            "organiseMyWhatsApp.exportAttendance", dryRun=self.config.dryRun
-        )
+        self.logger = getLogger("organiseMyFooty.exportAttendance")
 
     def run(self) -> None:
-        self.logger.info("starting export for group: %s", self.config.groupName)
-        self.logger.info("month window: %s", self.config.monthWindow.monthKey)
-        self.logger.info("output dir: %s", self.config.outputDir)
+        self.logger.info(
+            "%sstarting export for group: %s", self.prefix, self.config.groupName
+        )
+        self.logger.info(
+            "%smonth window: %s", self.prefix, self.config.monthWindow.monthKey
+        )
+        self.logger.info("%soutput dir: %s", self.prefix, self.config.outputDir)
 
         if self.config.dryRun:
             self.logger.info(
-                "dry run enabled; browser automation will still inspect the UI but will not overwrite exports",
+                "%sdry run enabled; browser automation will inspect the UI but will not overwrite exports",
+                self.prefix,
             )
 
         records = self.collectPollAttendance()
-        self.logger.info("poll vote rows collected: %s", len(records))
+        self.logger.info("%spoll vote rows collected: %s", self.prefix, len(records))
 
         rawRows = [asdict(record) for record in records]
         summaryRows = self.buildSummaryRows(records)
+        reportRows = self.buildAttendanceReportRows(records)
 
         if self.config.dryRun:
-            self.logger.info("would write polls.csv rows: %s", len(rawRows))
             self.logger.info(
-                "would write attendanceSummary.csv rows: %s",
+                "%swould write polls.csv rows: %s", self.prefix, len(rawRows)
+            )
+            self.logger.info(
+                "%swould write attendanceSummary.csv rows: %s",
+                self.prefix,
                 len(summaryRows),
             )
-            self.writePreviewJson(rawRows, summaryRows)
+            self.logger.info(
+                "%swould write attendanceReport.csv rows: %s",
+                self.prefix,
+                max(0, len(reportRows) - 2),
+            )
+            self.writePreviewJson(rawRows, summaryRows, reportRows)
             return
 
         writeCsv(
@@ -87,24 +110,40 @@ class AttendanceExporter:
             summaryRows,
             ["name", "yesCount", "noCount", "totalVotes", "pollsResponded"],
         )
-        self.writePreviewJson(rawRows, summaryRows)
-        self.logger.info("export complete")
+        self.writeAttendanceReportCsv(
+            self.config.outputDir / "attendanceReport.csv",
+            reportRows,
+        )
+        self.writePreviewJson(rawRows, summaryRows, reportRows)
+        self.logger.info("%sexport complete", self.prefix)
 
-    def writePreviewJson(self, rawRows: list[dict], summaryRows: list[dict]) -> None:
+    def writePreviewJson(
+        self,
+        rawRows: list[dict],
+        summaryRows: list[dict],
+        reportRows: list[list[str]],
+    ) -> None:
         previewPath = self.config.outputDir / "exportPreview.json"
         payload = {
             "groupName": self.config.groupName,
             "month": self.config.monthWindow.monthKey,
             "rawPollRows": rawRows,
             "summaryRows": summaryRows,
+            "attendanceReportRows": reportRows,
         }
         if self.config.dryRun:
-            self.logger.info("would write preview json: %s", previewPath)
+            self.logger.info("%swould write preview json: %s", self.prefix, previewPath)
             return
 
         previewPath.write_text(
             json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
         )
+
+    def writeAttendanceReportCsv(self, path: Path, rows: list[list[str]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerows(rows)
 
     def buildSummaryRows(self, records: list[PollRecord]) -> list[dict]:
         summary: dict[str, dict[str, int | set[str]]] = {}
@@ -126,7 +165,7 @@ class AttendanceExporter:
             row["pollsResponded"].add(f"{record.pollTitle}|{record.pollDateText}")  # type: ignore[union-attr]
 
         outputRows: list[dict] = []
-        for voterName in sorted(summary):
+        for voterName in sorted(summary, key=str.casefold):
             row = summary[voterName]
             outputRows.append(
                 {
@@ -139,26 +178,100 @@ class AttendanceExporter:
             )
         return outputRows
 
-    def collectPollAttendance(self) -> list[PollRecord]:
-        try:
-            from playwright.sync_api import (
-                sync_playwright,
-                TimeoutError as PlaywrightTimeoutError,
+    def buildAttendanceReportRows(self, records: list[PollRecord]) -> list[list[str]]:
+        """Build a two-row-header report with dynamic sessions.
+
+        Sessions are discovered from scraped poll titles. Week numbers are inferred
+        per repeated session name: the first poll for a session is week 1, the
+        second poll for that same session is week 2, and so on.
+        """
+        if not records:
+            return [[""], ["name"]]
+
+        pollSessions = self.buildPollSessions(records)
+        sessionNames = self.extractOrderedSessionNames(pollSessions)
+        maxWeek = max(session.weekNumber for session in pollSessions.values())
+
+        weekHeader = [""]
+        sessionHeader = ["name"]
+        for weekNumber in range(1, maxWeek + 1):
+            for sessionIndex, sessionName in enumerate(sessionNames):
+                weekHeader.append(f"week {weekNumber}" if sessionIndex == 0 else "")
+                sessionHeader.append(sessionName)
+
+        voterNames = sorted({record.voterName for record in records}, key=str.casefold)
+        attendance = self.buildAttendanceLookup(records, pollSessions)
+
+        rows = [weekHeader, sessionHeader]
+        for voterName in voterNames:
+            row = [voterName]
+            for weekNumber in range(1, maxWeek + 1):
+                for sessionName in sessionNames:
+                    row.append(attendance.get((voterName, weekNumber, sessionName), ""))
+            rows.append(row)
+
+        return rows
+
+    def buildPollSessions(
+        self, records: list[PollRecord]
+    ) -> OrderedDict[str, PollSession]:
+        pollKeys: OrderedDict[str, str] = OrderedDict()
+        for record in records:
+            pollKeys.setdefault(self.buildPollKey(record), record.pollTitle)
+
+        sessionCounts: defaultdict[str, int] = defaultdict(int)
+        pollSessions: OrderedDict[str, PollSession] = OrderedDict()
+
+        for pollKey, pollTitle in pollKeys.items():
+            sessionName = self.extractSessionName(pollTitle)
+            sessionCounts[sessionName] += 1
+            pollSessions[pollKey] = PollSession(
+                pollKey=pollKey,
+                pollTitle=pollTitle,
+                weekNumber=sessionCounts[sessionName],
+                sessionName=sessionName,
             )
-        except ModuleNotFoundError as exc:
-            raise ModuleNotFoundError(
-                "playwright is not installed; run: pip install playwright && playwright install chromium"
-            ) from exc
+
+        return pollSessions
+
+    def extractOrderedSessionNames(
+        self, pollSessions: OrderedDict[str, PollSession]
+    ) -> list[str]:
+        sessions: OrderedDict[str, None] = OrderedDict()
+        for pollSession in pollSessions.values():
+            sessions.setdefault(pollSession.sessionName, None)
+        return list(sessions.keys())
+
+    def buildAttendanceLookup(
+        self,
+        records: list[PollRecord],
+        pollSessions: OrderedDict[str, PollSession],
+    ) -> dict[tuple[str, int, str], str]:
+        attendance: dict[tuple[str, int, str], str] = {}
+        for record in records:
+            pollSession = pollSessions[self.buildPollKey(record)]
+            key = (record.voterName, pollSession.weekNumber, pollSession.sessionName)
+            current = attendance.get(key, "")
+
+            if record.option.lower() == "yes":
+                attendance[key] = "yes"
+            elif record.option.lower() == "no" and current != "yes":
+                attendance[key] = "no"
+
+        return attendance
+
+    def buildPollKey(self, record: PollRecord) -> str:
+        return f"{record.pollTitle}|{record.pollDateText}|{record.sourceHint[:80]}"
+
+    def extractSessionName(self, pollTitle: str) -> str:
+        title = " ".join(pollTitle.split()).strip()
+        return re.sub(r"\s+", " ", title) or "unknown session"
+
+    def collectPollAttendance(self) -> list[PollRecord]:
+        from playwright.sync_api import sync_playwright
 
         records: list[PollRecord] = []
         pollCount = 0
-
-        self.logger.info(
-            "launching browser (user_data_dir=%s, headless=%s, channel=%s)",
-            self.config.userDataDir,
-            self.config.headless,
-            self.config.browserChannel or "default",
-        )
 
         with sync_playwright() as playwright:
             browserContext = playwright.chromium.launch_persistent_context(
@@ -169,28 +282,35 @@ class AttendanceExporter:
             )
             try:
                 page = browserContext.new_page()
-                self.logger.info("navigating to %s", self.selectors.webUrl)
                 page.goto(self.selectors.webUrl)
-                self.logger.info("page loaded: %s", page.url)
                 self.waitForWhatsAppReady(page)
                 self.openGroup(page, self.config.groupName)
                 self.scrollChatHistory(page)
 
                 pollLocators = self.findPollCards(page)
-                self.logger.info("candidate poll cards found: %s", len(pollLocators))
+                self.logger.info(
+                    "%scandidate poll cards found: %s", self.prefix, len(pollLocators)
+                )
 
-                for index, pollTarget in enumerate(pollLocators, start=1):
+                for index, locator in enumerate(pollLocators, start=1):
                     if (
                         self.config.limitPolls is not None
                         and pollCount >= self.config.limitPolls
                     ):
                         self.logger.info(
-                            "poll limit reached: %s",
+                            "%spoll limit reached: %s",
+                            self.prefix,
                             self.config.limitPolls,
                         )
                         break
 
-                    sourceText = pollTarget.sourceText
+                    try:
+                        locator.scroll_into_view_if_needed(
+                            timeout=self.config.timeoutMs
+                        )
+                        sourceText = locator.inner_text(timeout=self.config.timeoutMs)
+                    except Exception:
+                        sourceText = ""
 
                     if (
                         self.config.pollTitleFilter
@@ -198,27 +318,29 @@ class AttendanceExporter:
                         not in sourceText.lower()
                     ):
                         self.logger.info(
-                            "skipping poll due to title filter: %s",
+                            "%sskipping poll due to title filter: %s",
+                            self.prefix,
                             self.config.pollTitleFilter,
                         )
                         continue
 
-                    self.logger.info("opening poll %s", index)
+                    self.logger.info("%sopening poll %s", self.prefix, index)
                     try:
-                        self.openPollTarget(page, pollTarget)
-                    except Exception as exc:
-                        self.logger.warning("Unable to open poll votes dialog: %s", exc)
-                        continue
+                        locator.click(timeout=self.config.timeoutMs)
+                    except Exception:
+                        try:
+                            locator.get_by_text(
+                                self.selectors.viewVotesText, exact=False
+                            ).click(timeout=self.config.timeoutMs)
+                        except Exception as exc:
+                            self.logger.warning(
+                                "Unable to open poll votes dialog: %s", exc
+                            )
+                            continue
 
-                    try:
-                        dialog = self.waitForDialog(page)
-                    except TimeoutError:
-                        self.logger.warning(
-                            "unable to locate votes dialog for poll %s; skipping",
-                            index,
-                        )
-                        self.closeDialog(page, dialog=None)
-                        continue
+                    dialog = self.waitForDialog(page)
+                    self.expandAllVoters(dialog)
+
                     pollTitle = (
                         self.extractPollTitle(dialog, sourceText=sourceText)
                         or "unknown poll"
@@ -239,7 +361,6 @@ class AttendanceExporter:
                             )
                         )
 
-                    noVoters: list[str] = []
                     if self.config.includeNoVotes:
                         noVoters = self.extractOptionVoters(
                             dialog, optionTexts=self.selectors.noOptionTexts
@@ -255,14 +376,6 @@ class AttendanceExporter:
                                 )
                             )
 
-                    self.logger.info(
-                        "poll %s: title=%r, yes=%s voter(s), no=%s voter(s)",
-                        index,
-                        pollTitle,
-                        len(yesVoters),
-                        len(noVoters),
-                    )
-
                     pollCount += 1
                     self.closeDialog(page, dialog)
 
@@ -273,42 +386,28 @@ class AttendanceExporter:
 
     def waitForWhatsAppReady(self, page) -> None:
         page.wait_for_load_state("domcontentloaded")
-        self.logger.info("waiting for WhatsApp Web to be ready...")
-        self.logger.info(
-            "(first run: if a QR code appears in the browser window, open WhatsApp on "
-            "your phone → Linked devices → Link a device and scan it; use --timeout-ms "
-            "to allow more time, e.g. --timeout-ms 300000)",
-        )
-        deadline = time.time() + max(120, self.config.timeoutMs / 1000)
-        startTime = time.time()
-        lastProgressLog = 0.0
+        self.logger.info("%swaiting for WhatsApp Web to be ready...", self.prefix)
+        deadline = time.time() + max(60, self.config.timeoutMs / 1000)
 
         while time.time() < deadline:
-            elapsed = int(time.time() - startTime)
-            if elapsed - lastProgressLog >= 10:
-                self.logger.info(
-                    "still waiting for whatsapp web (%ss elapsed)...",
-                    elapsed,
-                )
-                lastProgressLog = elapsed
-            for selector in self.selectors.iterReadySelectors():
+            for selector in self.selectors.iterSearchSelectors():
                 try:
                     locator = page.locator(selector).first
                     if locator.is_visible(timeout=1000):
-                        self.logger.info("whatsapp ready via selector: %s", selector)
+                        self.logger.info(
+                            "%swhatsapp ready via selector: %s", self.prefix, selector
+                        )
                         return
                 except Exception:
                     continue
             time.sleep(1)
 
         raise TimeoutError(
-            "whatsapp web did not become ready; if this is your first run, scan the QR "
-            "code that appears in the browser window using your phone's WhatsApp app. "
-            "Use --timeout-ms to allow more time (e.g. --timeout-ms 300000)."
+            "whatsapp web did not become ready; make sure you are logged in"
         )
 
     def openGroup(self, page, groupName: str) -> None:
-        self.logger.info("opening group: %s", groupName)
+        self.logger.info("%sopening group: %s", self.prefix, groupName)
 
         lastError: Optional[Exception] = None
         for selector in self.selectors.iterSearchSelectors():
@@ -317,10 +416,6 @@ class AttendanceExporter:
                 searchBox.click(timeout=self.config.timeoutMs)
                 searchBox.fill("")
                 searchBox.type(groupName, delay=40)
-                self.logger.info(
-                    "search box ready (selector: %s), typed group name",
-                    selector,
-                )
                 break
             except Exception as exc:
                 lastError = exc
@@ -330,18 +425,15 @@ class AttendanceExporter:
 
         candidate = page.get_by_text(groupName, exact=True).first
         candidate.click(timeout=self.config.timeoutMs)
-        self.logger.info("group chat opened")
 
     def scrollChatHistory(self, page, scrollPasses: int = 12) -> None:
-        self.logger.info("scrolling chat history to load older polls...")
-        for i in range(scrollPasses):
+        self.logger.info("%sscrolling chat history to load older polls...", self.prefix)
+        for _ in range(scrollPasses):
             page.mouse.wheel(0, -2000)
             page.wait_for_timeout(500)
-            if (i + 1) % 4 == 0 or i + 1 == scrollPasses:
-                self.logger.info("scroll pass %s/%s", i + 1, scrollPasses)
 
-    def findPollCards(self, page) -> list[PollTarget]:
-        pollLocators: list[PollTarget] = []
+    def findPollCards(self, page) -> list:
+        pollLocators: list = []
         seenKeys: set[str] = set()
 
         for selector in self.selectors.iterPollSelectors():
@@ -351,146 +443,62 @@ class AttendanceExporter:
             except Exception:
                 continue
 
-            self.logger.info("poll selector '%s' matched %s item(s)", selector, count)
-            if count:
-                self.logger.info(
-                    "scanning %s poll candidate(s) for selector '%s'",
-                    count,
-                    selector,
-                )
-
             for index in range(count):
                 item = locator.nth(index)
                 try:
                     text = item.inner_text(timeout=1000)
                 except Exception:
                     text = f"item-{index}"
-                messageTestId = self.extractMessageTestId(item)
-                key = f"{messageTestId or selector}|{text[:120]}"
+                key = f"{selector}|{text[:120]}"
                 if key in seenKeys:
                     continue
                 seenKeys.add(key)
-                pollLocators.append(
-                    PollTarget(
-                        selector=selector,
-                        sourceText=text,
-                        messageTestId=messageTestId or "",
-                    )
-                )
-                processed = index + 1
-                if count >= POLL_PROGRESS_INTERVAL and (
-                    processed % POLL_PROGRESS_INTERVAL == 0
-                ):
-                    self.logger.info(
-                        "processed %s/%s poll candidate(s) for selector '%s'",
-                        processed,
-                        count,
-                        selector,
-                    )
+                pollLocators.append(item)
 
-        self.logger.info(
-            "poll discovery complete: %s unique poll target(s)",
-            len(pollLocators),
-        )
         return pollLocators
 
-    def extractMessageTestId(self, locator) -> str:
-        """Return the nearest WhatsApp conversation message test id for a poll element."""
-        try:
-            container = locator.locator(
-                'xpath=ancestor-or-self::*[starts-with(@data-testid, "conv-msg-")][1]'
-            ).first
-            return container.get_attribute("data-testid") or ""
-        except Exception as exc:
-            self.logger.debug(
-                "unable to extract poll message test id: %s",
-                exc,
-            )
-            return ""
-
-    def extractPollSummaryText(self, sourceText: str) -> str:
-        """Return the first non-empty source line as a stable text hint for a poll."""
-        for line in sourceText.splitlines():
-            value = line.strip()
-            if value:
-                return value
-        return ""
-
-    def buildPollButtonSelector(self, pollTarget: PollTarget) -> str:
-        """Build the most stable available selector for the target poll vote button."""
-        if pollTarget.messageTestId:
-            return (
-                f'[data-testid="{pollTarget.messageTestId}"] '
-                '[data-testid="poll-view-votes"]'
-            )
-        return pollTarget.selector
-
-    def openPollTarget(self, page, pollTarget: PollTarget) -> None:
-        """Open a poll using stable test ids first, then text-filtered and generic fallbacks."""
-        candidateLocators = [
-            page.locator(self.buildPollButtonSelector(pollTarget)).first
-        ]
-        summaryText = self.extractPollSummaryText(pollTarget.sourceText)
-        if summaryText:
-            candidateLocators.append(
-                page.locator(pollTarget.selector).filter(has_text=summaryText).first
-            )
-        if pollTarget.selector != self.buildPollButtonSelector(pollTarget):
-            candidateLocators.append(page.locator(pollTarget.selector).first)
-
-        lastError: Exception = RuntimeError("failed to interact with poll vote button")
-        for locator in candidateLocators:
-            try:
-                locator.scroll_into_view_if_needed(timeout=self.config.timeoutMs)
-                locator.click(timeout=self.config.timeoutMs)
-                return
-            except Exception as exc:
-                lastError = exc
-
-        raise RuntimeError(
-            "failed to interact with poll vote button "
-            f"after {len(candidateLocators)} attempt(s) for {summaryText!r}"
-        ) from lastError
-
     def waitForDialog(self, page):
-        timeoutMs = max(self.config.timeoutMs, DIALOG_POLL_INTERVAL_MS)
-        deadline = time.time() + (timeoutMs / 1000)
-        selectors = tuple(self.selectors.iterDialogSelectors())
+        for selector in self.selectors.iterDialogSelectors():
+            try:
+                dialog = page.locator(selector).last
+                dialog.wait_for(state="visible", timeout=self.config.timeoutMs)
+                return dialog
+            except Exception:
+                continue
+        raise TimeoutError("unable to locate votes dialog")
 
-        while time.time() < deadline:
-            remainingMs = int((deadline - time.time()) * 1000)
-            if remainingMs <= 0:
+    def expandAllVoters(self, dialog) -> None:
+        """Expand all lazy-loaded voter rows inside the current poll dialog."""
+        for _ in range(10):
+            clicked = False
+            try:
+                buttons = dialog.get_by_text(re.compile(r"^See all", re.IGNORECASE))
+                count = buttons.count()
+            except Exception:
                 break
-            # Keep the overall deadline separate from the per-selector probe timeout so
-            # we can retry multiple selector candidates within the remaining time budget.
-            probeTimeoutMs = min(1000, remainingMs)
-            for selector in selectors:
+
+            for index in range(count):
                 try:
-                    dialog = page.locator(selector).last
-                    if dialog.is_visible(timeout=probeTimeoutMs):
-                        self.logger.info(
-                            "votes dialog opened via selector: %s",
-                            selector,
-                        )
-                        return dialog
+                    button = buttons.nth(index)
+                    if button.is_visible(timeout=500):
+                        button.click(timeout=self.config.timeoutMs)
+                        dialog.page.wait_for_timeout(300)
+                        clicked = True
                 except Exception:
                     continue
 
-            page.wait_for_timeout(DIALOG_POLL_INTERVAL_MS)
-
-        raise TimeoutError("unable to locate votes dialog")
+            if not clicked:
+                break
 
     def extractPollTitle(self, dialog, sourceText: str = "") -> str:
-        try:
-            headings = dialog.locator("h1, h2, h3, [role='heading']")
-            if headings.count() > 0:
-                title = headings.first.inner_text(timeout=1000).strip()
-                if title:
-                    return title
-        except Exception:
-            pass
-
         lines = [line.strip() for line in sourceText.splitlines() if line.strip()]
+
+        # Typical poll card text:
+        # 0 = sender
+        # 1 = poll title/session
+        # 2 = Select one or more
+        if len(lines) >= 2:
+            return lines[1]
         if lines:
             return lines[0]
         return "unknown poll"
@@ -503,9 +511,9 @@ class AttendanceExporter:
         """
         Heuristic extractor.
 
-        The exact DOM for poll results may change.
-        This implementation looks for a visible section with the option label,
-        then collects person-like rows beneath it until the next option heading.
+        The exact DOM for poll results may change. This implementation looks for
+        a visible section with the option label, then collects person-like rows
+        beneath it until the next option heading.
         """
         optionNames = tuple(optionTexts)
         dialogText = dialog.inner_text(timeout=self.config.timeoutMs)
@@ -534,17 +542,17 @@ class AttendanceExporter:
         return self.cleanVoterNames(captured)
 
     def looksLikeVoteCount(self, line: str) -> bool:
-        compact = line.replace(" ", "")
-        return compact.isdigit() or bool(re.fullmatch(r"\d+votes?", line.lower()))
+        lowered = line.lower().strip()
+        compact = lowered.replace(" ", "")
+        return compact.isdigit() or bool(re.fullmatch(r"\d+votes?", lowered))
 
     def looksLikeSystemText(self, line: str) -> bool:
-        lowered = line.lower()
+        lowered = line.lower().strip()
         systemFragments = (
             "select one or more",
             "view votes",
-            "votes",
+            "poll details",
             "message",
-            "poll",
         )
         return any(fragment in lowered for fragment in systemFragments)
 
@@ -560,8 +568,14 @@ class AttendanceExporter:
                 continue
             if re.search(r"\b\d{1,2}:\d{2}\b", value):
                 continue
-            if value.lower() in {"yes", "no"}:
+            if value.lower() in {"yes", "no", "you"}:
                 continue
+            if value.lower().startswith("see all"):
+                continue
+            if value.lower().endswith("vote") or value.lower().endswith("votes"):
+                continue
+            if value.startswith("~ "):
+                value = value[2:].strip()
             if value in seen:
                 continue
             seen.add(value)
@@ -570,22 +584,18 @@ class AttendanceExporter:
         return cleaned
 
     def closeDialog(self, page, dialog) -> None:
-        for selector in (
-            self.selectors.closeDialogCandidates + self.selectors.backCandidates
-        ):
+        for selector in self.selectors.closeDialogCandidates:
             try:
                 control = page.locator(selector).first
                 if control.is_visible(timeout=1000):
                     control.click(timeout=self.config.timeoutMs)
                     page.wait_for_timeout(400)
-                    self.logger.info("closed dialog via selector: %s", selector)
                     return
             except Exception:
                 continue
 
         page.keyboard.press("Escape")
         page.wait_for_timeout(400)
-        self.logger.info("closed dialog via Escape key")
 
     def deduplicateRecords(self, records: list[PollRecord]) -> list[PollRecord]:
         output: list[PollRecord] = []
@@ -601,5 +611,4 @@ class AttendanceExporter:
                 continue
             seen.add(key)
             output.append(record)
-        self.logger.info("deduplication: %s → %s records", len(records), len(output))
         return output

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -45,7 +45,7 @@ class PollTarget:
 class DryRunMixin:
     @property
     def prefix(self) -> str:
-        return "...[] " if self.config.dryRun else "..."
+        return "[] " if self.config.dryRun else ""
 
 
 class AttendanceExporter(DryRunMixin):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, asdict
 from datetime import datetime
 from pathlib import Path
@@ -16,21 +17,33 @@ DIALOG_POLL_INTERVAL_MS = 250  # Poll frequently without busy-waiting the browse
 
 
 try:
-    from organiseMyProjects.logUtils import getLogger  # type: ignore
+    from organiseMyProjects.logUtils import getLogger as _logUtilsGetLogger  # type: ignore
 except Exception:  # pragma: no cover
-    import logging
+    _logUtilsGetLogger = None
 
-    def getLogger(name: str):  # type: ignore
-        logger = logging.getLogger(name)
-        if not logger.handlers:
-            logger.setLevel(logging.INFO)
-            handler = logging.StreamHandler()
-            formatter = logging.Formatter(
-                "%(asctime)s %(levelname)s %(name)s: %(message)s"
-            )
-            handler.setFormatter(formatter)
-            logger.addHandler(handler)
-        return logger
+
+def getLogger(name: str, dryRun: bool = False):  # type: ignore
+    if _logUtilsGetLogger is not None:
+        # Support both the richer organiseMyProjects logger signature and simpler
+        # variants so console logging still works across installed versions.
+        for kwargs in (
+            {"includeConsole": True, "dryRun": dryRun},
+            {"includeConsole": True},
+            {},
+        ):
+            try:
+                return _logUtilsGetLogger(name, **kwargs)
+            except TypeError:
+                continue
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger
 
 
 @dataclass(frozen=True)
@@ -54,7 +67,9 @@ class AttendanceExporter(DryRunMixin):
     ):
         self.config = config
         self.selectors = selectors or DEFAULT_SELECTORS
-        self.logger = getLogger("organiseMyWhatsApp.exportAttendance")
+        self.logger = getLogger(
+            "organiseMyWhatsApp.exportAttendance", dryRun=self.config.dryRun
+        )
 
     def run(self) -> None:
         self.logger.info(

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -383,6 +383,13 @@ class AttendanceExporter(DryRunMixin):
             self.logger.info(
                 "%spoll selector '%s' matched %s item(s)", self.prefix, selector, count
             )
+            if count:
+                self.logger.info(
+                    "%sscanning %s poll candidate(s) for selector '%s'",
+                    self.prefix,
+                    count,
+                    selector,
+                )
 
             for index in range(count):
                 item = locator.nth(index)
@@ -402,7 +409,21 @@ class AttendanceExporter(DryRunMixin):
                         messageTestId=messageTestId or "",
                     )
                 )
+                processed = index + 1
+                if count > 25 and (processed % 25 == 0 or processed == count):
+                    self.logger.info(
+                        "%sprocessed %s/%s poll candidate(s) for selector '%s'",
+                        self.prefix,
+                        processed,
+                        count,
+                        selector,
+                    )
 
+        self.logger.info(
+            "%spoll discovery complete: %s unique poll target(s)",
+            self.prefix,
+            len(pollLocators),
+        )
         return pollLocators
 
     def extractMessageTestId(self, locator) -> str:

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -42,13 +42,7 @@ class PollTarget:
     messageTestId: str = ""
 
 
-class DryRunMixin:
-    @property
-    def prefix(self) -> str:
-        return "[] " if self.config.dryRun else ""
-
-
-class AttendanceExporter(DryRunMixin):
+class AttendanceExporter:
     def __init__(
         self, config: RuntimeConfig, selectors: WhatsAppSelectors | None = None
     ):
@@ -59,33 +53,25 @@ class AttendanceExporter(DryRunMixin):
         )
 
     def run(self) -> None:
-        self.logger.info(
-            "%sstarting export for group: %s", self.prefix, self.config.groupName
-        )
-        self.logger.info(
-            "%smonth window: %s", self.prefix, self.config.monthWindow.monthKey
-        )
-        self.logger.info("%soutput dir: %s", self.prefix, self.config.outputDir)
+        self.logger.info("starting export for group: %s", self.config.groupName)
+        self.logger.info("month window: %s", self.config.monthWindow.monthKey)
+        self.logger.info("output dir: %s", self.config.outputDir)
 
         if self.config.dryRun:
             self.logger.info(
-                "%sdry run enabled; browser automation will still inspect the UI but will not overwrite exports",
-                self.prefix,
+                "dry run enabled; browser automation will still inspect the UI but will not overwrite exports",
             )
 
         records = self.collectPollAttendance()
-        self.logger.info("%spoll vote rows collected: %s", self.prefix, len(records))
+        self.logger.info("poll vote rows collected: %s", len(records))
 
         rawRows = [asdict(record) for record in records]
         summaryRows = self.buildSummaryRows(records)
 
         if self.config.dryRun:
+            self.logger.info("would write polls.csv rows: %s", len(rawRows))
             self.logger.info(
-                "%swould write polls.csv rows: %s", self.prefix, len(rawRows)
-            )
-            self.logger.info(
-                "%swould write attendanceSummary.csv rows: %s",
-                self.prefix,
+                "would write attendanceSummary.csv rows: %s",
                 len(summaryRows),
             )
             self.writePreviewJson(rawRows, summaryRows)
@@ -102,7 +88,7 @@ class AttendanceExporter(DryRunMixin):
             ["name", "yesCount", "noCount", "totalVotes", "pollsResponded"],
         )
         self.writePreviewJson(rawRows, summaryRows)
-        self.logger.info("%sexport complete", self.prefix)
+        self.logger.info("export complete")
 
     def writePreviewJson(self, rawRows: list[dict], summaryRows: list[dict]) -> None:
         previewPath = self.config.outputDir / "exportPreview.json"
@@ -113,7 +99,7 @@ class AttendanceExporter(DryRunMixin):
             "summaryRows": summaryRows,
         }
         if self.config.dryRun:
-            self.logger.info("%swould write preview json: %s", self.prefix, previewPath)
+            self.logger.info("would write preview json: %s", previewPath)
             return
 
         previewPath.write_text(
@@ -168,8 +154,7 @@ class AttendanceExporter(DryRunMixin):
         pollCount = 0
 
         self.logger.info(
-            "%slaunching browser (user_data_dir=%s, headless=%s, channel=%s)",
-            self.prefix,
+            "launching browser (user_data_dir=%s, headless=%s, channel=%s)",
             self.config.userDataDir,
             self.config.headless,
             self.config.browserChannel or "default",
@@ -184,19 +169,15 @@ class AttendanceExporter(DryRunMixin):
             )
             try:
                 page = browserContext.new_page()
-                self.logger.info(
-                    "%snavigating to %s", self.prefix, self.selectors.webUrl
-                )
+                self.logger.info("navigating to %s", self.selectors.webUrl)
                 page.goto(self.selectors.webUrl)
-                self.logger.info("%spage loaded: %s", self.prefix, page.url)
+                self.logger.info("page loaded: %s", page.url)
                 self.waitForWhatsAppReady(page)
                 self.openGroup(page, self.config.groupName)
                 self.scrollChatHistory(page)
 
                 pollLocators = self.findPollCards(page)
-                self.logger.info(
-                    "%scandidate poll cards found: %s", self.prefix, len(pollLocators)
-                )
+                self.logger.info("candidate poll cards found: %s", len(pollLocators))
 
                 for index, pollTarget in enumerate(pollLocators, start=1):
                     if (
@@ -204,8 +185,7 @@ class AttendanceExporter(DryRunMixin):
                         and pollCount >= self.config.limitPolls
                     ):
                         self.logger.info(
-                            "%spoll limit reached: %s",
-                            self.prefix,
+                            "poll limit reached: %s",
                             self.config.limitPolls,
                         )
                         break
@@ -218,13 +198,12 @@ class AttendanceExporter(DryRunMixin):
                         not in sourceText.lower()
                     ):
                         self.logger.info(
-                            "%sskipping poll due to title filter: %s",
-                            self.prefix,
+                            "skipping poll due to title filter: %s",
                             self.config.pollTitleFilter,
                         )
                         continue
 
-                    self.logger.info("%sopening poll %s", self.prefix, index)
+                    self.logger.info("opening poll %s", index)
                     try:
                         self.openPollTarget(page, pollTarget)
                     except Exception as exc:
@@ -235,8 +214,7 @@ class AttendanceExporter(DryRunMixin):
                         dialog = self.waitForDialog(page)
                     except TimeoutError:
                         self.logger.warning(
-                            "%sunable to locate votes dialog for poll %s; skipping",
-                            self.prefix,
+                            "unable to locate votes dialog for poll %s; skipping",
                             index,
                         )
                         self.closeDialog(page, dialog=None)
@@ -278,8 +256,7 @@ class AttendanceExporter(DryRunMixin):
                             )
 
                     self.logger.info(
-                        "%spoll %s: title=%r, yes=%s voter(s), no=%s voter(s)",
-                        self.prefix,
+                        "poll %s: title=%r, yes=%s voter(s), no=%s voter(s)",
                         index,
                         pollTitle,
                         len(yesVoters),
@@ -296,12 +273,11 @@ class AttendanceExporter(DryRunMixin):
 
     def waitForWhatsAppReady(self, page) -> None:
         page.wait_for_load_state("domcontentloaded")
-        self.logger.info("%swaiting for WhatsApp Web to be ready...", self.prefix)
+        self.logger.info("waiting for WhatsApp Web to be ready...")
         self.logger.info(
-            "%s(first run: if a QR code appears in the browser window, open WhatsApp on "
+            "(first run: if a QR code appears in the browser window, open WhatsApp on "
             "your phone → Linked devices → Link a device and scan it; use --timeout-ms "
             "to allow more time, e.g. --timeout-ms 300000)",
-            self.prefix,
         )
         deadline = time.time() + max(120, self.config.timeoutMs / 1000)
         startTime = time.time()
@@ -311,8 +287,7 @@ class AttendanceExporter(DryRunMixin):
             elapsed = int(time.time() - startTime)
             if elapsed - lastProgressLog >= 10:
                 self.logger.info(
-                    "%sstill waiting for whatsapp web (%ss elapsed)...",
-                    self.prefix,
+                    "still waiting for whatsapp web (%ss elapsed)...",
                     elapsed,
                 )
                 lastProgressLog = elapsed
@@ -320,9 +295,7 @@ class AttendanceExporter(DryRunMixin):
                 try:
                     locator = page.locator(selector).first
                     if locator.is_visible(timeout=1000):
-                        self.logger.info(
-                            "%swhatsapp ready via selector: %s", self.prefix, selector
-                        )
+                        self.logger.info("whatsapp ready via selector: %s", selector)
                         return
                 except Exception:
                     continue
@@ -335,7 +308,7 @@ class AttendanceExporter(DryRunMixin):
         )
 
     def openGroup(self, page, groupName: str) -> None:
-        self.logger.info("%sopening group: %s", self.prefix, groupName)
+        self.logger.info("opening group: %s", groupName)
 
         lastError: Optional[Exception] = None
         for selector in self.selectors.iterSearchSelectors():
@@ -345,8 +318,7 @@ class AttendanceExporter(DryRunMixin):
                 searchBox.fill("")
                 searchBox.type(groupName, delay=40)
                 self.logger.info(
-                    "%ssearch box ready (selector: %s), typed group name",
-                    self.prefix,
+                    "search box ready (selector: %s), typed group name",
                     selector,
                 )
                 break
@@ -358,17 +330,15 @@ class AttendanceExporter(DryRunMixin):
 
         candidate = page.get_by_text(groupName, exact=True).first
         candidate.click(timeout=self.config.timeoutMs)
-        self.logger.info("%sgroup chat opened", self.prefix)
+        self.logger.info("group chat opened")
 
     def scrollChatHistory(self, page, scrollPasses: int = 12) -> None:
-        self.logger.info("%sscrolling chat history to load older polls...", self.prefix)
+        self.logger.info("scrolling chat history to load older polls...")
         for i in range(scrollPasses):
             page.mouse.wheel(0, -2000)
             page.wait_for_timeout(500)
             if (i + 1) % 4 == 0 or i + 1 == scrollPasses:
-                self.logger.info(
-                    "%sscroll pass %s/%s", self.prefix, i + 1, scrollPasses
-                )
+                self.logger.info("scroll pass %s/%s", i + 1, scrollPasses)
 
     def findPollCards(self, page) -> list[PollTarget]:
         pollLocators: list[PollTarget] = []
@@ -381,13 +351,10 @@ class AttendanceExporter(DryRunMixin):
             except Exception:
                 continue
 
-            self.logger.info(
-                "%spoll selector '%s' matched %s item(s)", self.prefix, selector, count
-            )
+            self.logger.info("poll selector '%s' matched %s item(s)", selector, count)
             if count:
                 self.logger.info(
-                    "%sscanning %s poll candidate(s) for selector '%s'",
-                    self.prefix,
+                    "scanning %s poll candidate(s) for selector '%s'",
                     count,
                     selector,
                 )
@@ -415,16 +382,14 @@ class AttendanceExporter(DryRunMixin):
                     processed % POLL_PROGRESS_INTERVAL == 0
                 ):
                     self.logger.info(
-                        "%sprocessed %s/%s poll candidate(s) for selector '%s'",
-                        self.prefix,
+                        "processed %s/%s poll candidate(s) for selector '%s'",
                         processed,
                         count,
                         selector,
                     )
 
         self.logger.info(
-            "%spoll discovery complete: %s unique poll target(s)",
-            self.prefix,
+            "poll discovery complete: %s unique poll target(s)",
             len(pollLocators),
         )
         return pollLocators
@@ -438,8 +403,7 @@ class AttendanceExporter(DryRunMixin):
             return container.get_attribute("data-testid") or ""
         except Exception as exc:
             self.logger.debug(
-                "%sunable to extract poll message test id: %s",
-                self.prefix,
+                "unable to extract poll message test id: %s",
                 exc,
             )
             return ""
@@ -505,8 +469,7 @@ class AttendanceExporter(DryRunMixin):
                     dialog = page.locator(selector).last
                     if dialog.is_visible(timeout=probeTimeoutMs):
                         self.logger.info(
-                            "%svotes dialog opened via selector: %s",
-                            self.prefix,
+                            "votes dialog opened via selector: %s",
                             selector,
                         )
                         return dialog
@@ -615,16 +578,14 @@ class AttendanceExporter(DryRunMixin):
                 if control.is_visible(timeout=1000):
                     control.click(timeout=self.config.timeoutMs)
                     page.wait_for_timeout(400)
-                    self.logger.info(
-                        "%sclosed dialog via selector: %s", self.prefix, selector
-                    )
+                    self.logger.info("closed dialog via selector: %s", selector)
                     return
             except Exception:
                 continue
 
         page.keyboard.press("Escape")
         page.wait_for_timeout(400)
-        self.logger.info("%sclosed dialog via Escape key", self.prefix)
+        self.logger.info("closed dialog via Escape key")
 
     def deduplicateRecords(self, records: list[PollRecord]) -> list[PollRecord]:
         output: list[PollRecord] = []
@@ -640,7 +601,5 @@ class AttendanceExporter(DryRunMixin):
                 continue
             seen.add(key)
             output.append(record)
-        self.logger.info(
-            "%sdeduplication: %s → %s records", self.prefix, len(records), len(output)
-        )
+        self.logger.info("deduplication: %s → %s records", len(records), len(output))
         return output

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -149,10 +149,15 @@ class AttendanceExporter(DryRunMixin):
         return outputRows
 
     def collectPollAttendance(self) -> list[PollRecord]:
-        from playwright.sync_api import (
-            sync_playwright,
-            TimeoutError as PlaywrightTimeoutError,
-        )
+        try:
+            from playwright.sync_api import (
+                sync_playwright,
+                TimeoutError as PlaywrightTimeoutError,
+            )
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "playwright is not installed; run: pip install playwright && playwright install chromium"
+            ) from exc
 
         records: list[PollRecord] = []
         pollCount = 0

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -473,7 +473,7 @@ class AttendanceExporter(DryRunMixin):
                 lastError = exc
 
         if lastError is None:
-            raise RuntimeError("unable to build poll vote locator")
+            raise RuntimeError("failed to interact with poll vote button")
         raise lastError
 
     def waitForDialog(self, page):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -467,7 +467,7 @@ class AttendanceExporter(DryRunMixin):
         if pollTarget.selector != self.buildPollButtonSelector(pollTarget):
             candidateLocators.append(page.locator(pollTarget.selector).first)
 
-        lastError: Exception | None = None
+        lastError: Exception = RuntimeError("failed to interact with poll vote button")
         for locator in candidateLocators:
             try:
                 locator.scroll_into_view_if_needed(timeout=self.config.timeoutMs)
@@ -476,7 +476,6 @@ class AttendanceExporter(DryRunMixin):
             except Exception as exc:
                 lastError = exc
 
-        assert lastError is not None
         raise lastError
 
     def waitForDialog(self, page):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -58,6 +58,8 @@ class PollRecord:
 
 @dataclass(frozen=True)
 class PollTarget:
+    """Stable poll target data used to refind a vote button after the UI changes."""
+
     selector: str
     sourceText: str
     messageTestId: str = ""
@@ -434,7 +436,12 @@ class AttendanceExporter(DryRunMixin):
                 'xpath=ancestor-or-self::*[starts-with(@data-testid, "conv-msg-")][1]'
             ).first
             return container.get_attribute("data-testid") or ""
-        except Exception:
+        except Exception as exc:
+            self.logger.debug(
+                "%sunable to extract poll message test id: %s",
+                self.prefix,
+                exc,
+            )
             return ""
 
     def extractPollSummaryText(self, sourceText: str) -> str:
@@ -476,7 +483,10 @@ class AttendanceExporter(DryRunMixin):
             except Exception as exc:
                 lastError = exc
 
-        raise lastError
+        raise RuntimeError(
+            "failed to interact with poll vote button "
+            f"after {len(candidateLocators)} attempt(s) for {summaryText!r}"
+        ) from lastError
 
     def waitForDialog(self, page):
         timeoutMs = max(self.config.timeoutMs, DIALOG_POLL_INTERVAL_MS)

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -476,8 +476,7 @@ class AttendanceExporter(DryRunMixin):
             except Exception as exc:
                 lastError = exc
 
-        if lastError is None:
-            raise RuntimeError("failed to interact with poll vote button")
+        assert lastError is not None
         raise lastError
 
     def waitForDialog(self, page):

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -472,9 +472,9 @@ class AttendanceExporter(DryRunMixin):
             except Exception as exc:
                 lastError = exc
 
-        if lastError is not None:
-            raise lastError
-        raise RuntimeError("unable to open poll votes dialog")
+        if lastError is None:
+            raise RuntimeError("unable to build poll vote locator")
+        raise lastError
 
     def waitForDialog(self, page):
         timeoutMs = max(self.config.timeoutMs, DIALOG_POLL_INTERVAL_MS)

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -269,7 +269,13 @@ class AttendanceExporter(DryRunMixin):
     def waitForWhatsAppReady(self, page) -> None:
         page.wait_for_load_state("domcontentloaded")
         self.logger.info("%swaiting for WhatsApp Web to be ready...", self.prefix)
-        deadline = time.time() + max(60, self.config.timeoutMs / 1000)
+        self.logger.info(
+            "%s(first run: if a QR code appears in the browser window, open WhatsApp on "
+            "your phone → Linked devices → Link a device and scan it; use --timeout-ms "
+            "to allow more time, e.g. --timeout-ms 300000)",
+            self.prefix,
+        )
+        deadline = time.time() + max(120, self.config.timeoutMs / 1000)
 
         while time.time() < deadline:
             for selector in self.selectors.iterSearchSelectors():
@@ -285,7 +291,9 @@ class AttendanceExporter(DryRunMixin):
             time.sleep(1)
 
         raise TimeoutError(
-            "whatsapp web did not become ready; make sure you are logged in"
+            "whatsapp web did not become ready; if this is your first run, scan the QR "
+            "code that appears in the browser window using your phone's WhatsApp app. "
+            "Use --timeout-ms to allow more time (e.g. --timeout-ms 300000)."
         )
 
     def openGroup(self, page, groupName: str) -> None:

--- a/src/whatsappAttendance.py
+++ b/src/whatsappAttendance.py
@@ -428,6 +428,7 @@ class AttendanceExporter(DryRunMixin):
         return pollLocators
 
     def extractMessageTestId(self, locator) -> str:
+        """Return the nearest WhatsApp conversation message test id for a poll element."""
         try:
             container = locator.locator(
                 'xpath=ancestor-or-self::*[starts-with(@data-testid, "conv-msg-")][1]'
@@ -437,6 +438,7 @@ class AttendanceExporter(DryRunMixin):
             return ""
 
     def extractPollSummaryText(self, sourceText: str) -> str:
+        """Return the first non-empty source line as a stable text hint for a poll."""
         for line in sourceText.splitlines():
             value = line.strip()
             if value:
@@ -444,6 +446,7 @@ class AttendanceExporter(DryRunMixin):
         return ""
 
     def buildPollButtonSelector(self, pollTarget: PollTarget) -> str:
+        """Build the most stable available selector for the target poll vote button."""
         if pollTarget.messageTestId:
             return (
                 f'[data-testid="{pollTarget.messageTestId}"] '
@@ -452,6 +455,7 @@ class AttendanceExporter(DryRunMixin):
         return pollTarget.selector
 
     def openPollTarget(self, page, pollTarget: PollTarget) -> None:
+        """Open a poll using stable test ids first, then text-filtered and generic fallbacks."""
         candidateLocators = [
             page.locator(self.buildPollButtonSelector(pollTarget)).first
         ]

--- a/src/whatsappSelectors.py
+++ b/src/whatsappSelectors.py
@@ -51,7 +51,7 @@ class WhatsAppSelectors:
     yesOptionTexts: tuple[str, ...] = ("Yes",)
     noOptionTexts: tuple[str, ...] = ("No",)
 
-    likelyMessageTimePattern: str = r"\\b\\d{1,2}:\\d{2}\\b"
+    likelyMessageTimePattern: str = r"\b\d{1,2}:\d{2}\b"
 
     def iterSearchSelectors(self) -> Iterable[str]:
         return self.searchBoxCandidates

--- a/src/whatsappSelectors.py
+++ b/src/whatsappSelectors.py
@@ -54,8 +54,17 @@ class WhatsAppSelectors:
     viewVotesText: str = "View votes"
 
     dialogCandidates: tuple[str, ...] = (
+        # Semantic dialog roles — catches some WhatsApp Web builds.
         'div[role="dialog"]',
         'div[aria-modal="true"]',
+        # data-testid patterns used in recent WhatsApp Web builds.
+        '[data-testid="popup-contents"]',
+        '[data-testid="drawer"]',
+        # Animation/modal attribute used in some builds.
+        'div[data-animate-modal-body]',
+        # Aria-labelled panels that appear for vote results.
+        '[aria-label="Poll results"]',
+        '[aria-label="View votes"]',
     )
 
     closeDialogCandidates: tuple[str, ...] = (

--- a/src/whatsappSelectors.py
+++ b/src/whatsappSelectors.py
@@ -47,6 +47,7 @@ class WhatsAppSelectors:
     )
 
     pollCardCandidates: tuple[str, ...] = (
+        '[data-testid="poll-view-votes"]',
         'div[role="button"]:has-text("View votes")',
         'div:has-text("View votes")',
     )

--- a/src/whatsappSelectors.py
+++ b/src/whatsappSelectors.py
@@ -61,10 +61,19 @@ class WhatsAppSelectors:
         '[data-testid="popup-contents"]',
         '[data-testid="drawer"]',
         # Animation/modal attribute used in some builds.
-        'div[data-animate-modal-body]',
+        "div[data-animate-modal-body]",
         # Aria-labelled panels that appear for vote results.
         '[aria-label="Poll results"]',
         '[aria-label="View votes"]',
+        # Fallbacks for drawer-like vote panels that expose back/close controls.
+        'aside:has([aria-label="Back"])',
+        'aside:has([aria-label="Close"])',
+        'section:has([aria-label="Back"])',
+        'section:has([aria-label="Close"])',
+        # Last-resort English-text fallbacks for current WhatsApp Web poll panels.
+        # Keep these near the end because they are more brittle than aria/test-id selectors.
+        'div:has([aria-label="Back"]):has-text("Yes")',
+        'div:has([aria-label="Close"]):has-text("Yes")',
     )
 
     closeDialogCandidates: tuple[str, ...] = (

--- a/src/whatsappSelectors.py
+++ b/src/whatsappSelectors.py
@@ -15,7 +15,27 @@ class WhatsAppSelectors:
 
     webUrl: str = "https://web.whatsapp.com/"
 
+    # Broad selectors — any one visible means WhatsApp Web has fully loaded.
+    # Used only by waitForWhatsAppReady; add new entries here if the UI changes.
+    readyIndicatorCandidates: tuple[str, ...] = (
+        '[aria-label="Search or start a new chat"]',
+        '[placeholder="Search or start a new chat"]',
+        '[data-testid="chat-list"]',
+        '[aria-label="Chat list"]',
+        "#pane-side",
+        # Legacy data-tab attributes (older WhatsApp Web builds)
+        '[contenteditable="true"][data-tab="3"]',
+        '[contenteditable="true"][data-tab="4"]',
+    )
+
+    # Interactive search-box selectors — must be clickable/typeable.
+    # Used by openGroup to find and focus the search input.
     searchBoxCandidates: tuple[str, ...] = (
+        '[aria-label="Search or start a new chat"]',
+        '[placeholder="Search or start a new chat"]',
+        '[data-testid="search-input"]',
+        '[title="Search or start a new chat"]',
+        # Legacy data-tab attributes (older WhatsApp Web builds)
         '[contenteditable="true"][data-tab="3"]',
         '[contenteditable="true"][data-tab="4"]',
         'div[role="textbox"]',
@@ -52,6 +72,9 @@ class WhatsAppSelectors:
     noOptionTexts: tuple[str, ...] = ("No",)
 
     likelyMessageTimePattern: str = r"\b\d{1,2}:\d{2}\b"
+
+    def iterReadySelectors(self) -> Iterable[str]:
+        return self.readyIndicatorCandidates
 
     def iterSearchSelectors(self) -> Iterable[str]:
         return self.searchBoxCandidates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,11 @@ def _fake_get_logger(name: str, **kwargs):
     return _FakeStructuredLogger(name, **kwargs)
 
 
-organiseMyProjects = types.ModuleType("organiseMyProjects")
-logUtils = types.ModuleType("organiseMyProjects.logUtils")
-logUtils.getLogger = _fake_get_logger
-organiseMyProjects.logUtils = logUtils
-sys.modules.setdefault("organiseMyProjects", organiseMyProjects)
-sys.modules.setdefault("organiseMyProjects.logUtils", logUtils)
+_stubbed_organiseMyProjects = types.ModuleType("organiseMyProjects")
+_stubbed_logUtils = types.ModuleType("organiseMyProjects.logUtils")
+_stubbed_logUtils.getLogger = _fake_get_logger
+_stubbed_organiseMyProjects.logUtils = _stubbed_logUtils
+sys.modules.setdefault("organiseMyProjects", _stubbed_organiseMyProjects)
+sys.modules.setdefault("organiseMyProjects.logUtils", _stubbed_logUtils)
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,47 @@
-"""Pytest configuration: add src/ to sys.path so test modules can import source files."""
+"""Pytest configuration for source imports and logUtils stubs."""
+
 import sys
+import types
 from pathlib import Path
+
+
+class _FakeStructuredLogger:
+    def __init__(self, name: str, **kwargs):
+        self.name = name
+        self.kwargs = kwargs
+
+    def info(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    def action(self, *args, **kwargs):
+        return None
+
+    def doing(self, *args, **kwargs):
+        return None
+
+    def done(self, *args, **kwargs):
+        return None
+
+    def value(self, *args, **kwargs):
+        return None
+
+
+def _fake_get_logger(name: str, **kwargs):
+    return _FakeStructuredLogger(name, **kwargs)
+
+
+organiseMyProjects = types.ModuleType("organiseMyProjects")
+logUtils = types.ModuleType("organiseMyProjects.logUtils")
+logUtils.getLogger = _fake_get_logger
+logUtils.thisApplication = "organiseMyFooty"
+organiseMyProjects.logUtils = logUtils
+sys.modules.setdefault("organiseMyProjects", organiseMyProjects)
+sys.modules.setdefault("organiseMyProjects.logUtils", logUtils)
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 
 class _FakeStructuredLogger:
+    """Test stub for organiseMyProjects.logUtils logger instances."""
+
     def __init__(self, name: str, **kwargs):
         self.name = name
         self.kwargs = kwargs
@@ -33,6 +35,7 @@ class _FakeStructuredLogger:
 
 
 def _fake_get_logger(name: str, **kwargs):
+    """Return a stub logger matching the organiseMyProjects.logUtils factory."""
     return _FakeStructuredLogger(name, **kwargs)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def _fake_get_logger(name: str, **kwargs):
 organiseMyProjects = types.ModuleType("organiseMyProjects")
 logUtils = types.ModuleType("organiseMyProjects.logUtils")
 logUtils.getLogger = _fake_get_logger
-logUtils.thisApplication = "organiseMyFooty"
 organiseMyProjects.logUtils = logUtils
 sys.modules.setdefault("organiseMyProjects", organiseMyProjects)
 sys.modules.setdefault("organiseMyProjects.logUtils", logUtils)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,25 +11,25 @@ class _FakeStructuredLogger:
         self.kwargs = kwargs
 
     def info(self, *args, **kwargs):
-        return None
+        pass
 
     def warning(self, *args, **kwargs):
-        return None
+        pass
 
     def debug(self, *args, **kwargs):
-        return None
+        pass
 
     def action(self, *args, **kwargs):
-        return None
+        pass
 
     def doing(self, *args, **kwargs):
-        return None
+        pass
 
     def done(self, *args, **kwargs):
-        return None
+        pass
 
     def value(self, *args, **kwargs):
-        return None
+        pass
 
 
 def _fake_get_logger(name: str, **kwargs):

--- a/tests/runLinter.py
+++ b/tests/runLinter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """CLI entry point for the GUI Naming Linter."""
 
 import argparse

--- a/tests/testAttendanceConfig.py
+++ b/tests/testAttendanceConfig.py
@@ -1,4 +1,5 @@
 """Tests for attendanceConfig module."""
+
 from __future__ import annotations
 
 import csv

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -272,3 +272,33 @@ class TestDryRunPrefix:
     def test_prefix_when_dry_run_false(self):
         exporter = _make_exporter(dryRun=False)
         assert exporter.prefix == "..."
+
+
+# ---------------------------------------------------------------------------
+# extractLikelyDateText
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLikelyDateText:
+    def test_extracts_time_from_source_text(self):
+        exporter = _make_exporter()
+        result = exporter.extractLikelyDateText("Training tonight\n10:30\nYes")
+        assert result == "10:30"
+
+    def test_extracts_single_digit_hour(self):
+        exporter = _make_exporter()
+        result = exporter.extractLikelyDateText("Poll sent 9:05 am")
+        assert result == "9:05"
+
+    def test_returns_empty_string_when_no_time(self):
+        exporter = _make_exporter()
+        result = exporter.extractLikelyDateText("Training tonight")
+        assert result == ""
+
+    def test_does_not_match_partial_numbers(self):
+        exporter = _make_exporter()
+        # "1234:56" is not a plausible time; the regex requires word boundaries
+        # on both sides of the pattern, so it must not be surrounded by word
+        # characters (digits or letters).
+        result = exporter.extractLikelyDateText("code1234:56end")
+        assert result == ""

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -371,7 +372,7 @@ class TestPollTargetHelpers:
 
 
 class TestLoggerInitialisation:
-    def test_uses_log_utils_logger_with_console_enabled(self, monkeypatch):
+    def test_passes_include_console_true_to_log_utils(self, monkeypatch):
         captured = {}
 
         def fake_get_logger(name, **kwargs):
@@ -389,7 +390,8 @@ class TestLoggerInitialisation:
             "kwargs": {"includeConsole": True, "dryRun": True},
         }
 
-    def test_passes_dry_run_state_to_log_utils(self, monkeypatch):
+    @pytest.mark.parametrize("dry_run", [False, True])
+    def test_passes_dry_run_state_to_log_utils(self, monkeypatch, dry_run):
         captured = {}
 
         def fake_get_logger(name, **kwargs):
@@ -399,13 +401,31 @@ class TestLoggerInitialisation:
 
         monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", fake_get_logger)
 
-        logger = whatsappAttendance.getLogger("test.logger", dryRun=False)
+        logger = whatsappAttendance.getLogger("test.logger", dryRun=dry_run)
 
         assert logger == "logger"
         assert captured == {
             "name": "test.logger",
-            "kwargs": {"includeConsole": True, "dryRun": False},
+            "kwargs": {"includeConsole": True, "dryRun": dry_run},
         }
+
+
+class TestLogUtilsTestStub:
+    def test_conftest_installs_log_utils_stub(self):
+        log_utils = sys.modules["organiseMyProjects.logUtils"]
+
+        logger = log_utils.getLogger("stub.logger", includeConsole=True, dryRun=True)
+
+        assert logger.name == "stub.logger"
+        assert logger.kwargs == {"includeConsole": True, "dryRun": True}
+
+        assert logger.info("message") is None
+        assert logger.warning("message") is None
+        assert logger.debug("message") is None
+        assert logger.action("message") is None
+        assert logger.doing("message") is None
+        assert logger.done("message") is None
+        assert logger.value("name", "value") is None
 
 
 class TestPollTargetOpening:

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -1,4 +1,5 @@
 """Tests for non-browser helper methods in whatsappAttendance module."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -9,7 +10,6 @@ from attendanceConfig import MonthWindow, RuntimeConfig
 from whatsappAttendance import AttendanceExporter, PollRecord
 
 from datetime import date
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -302,3 +302,87 @@ class TestExtractLikelyDateText:
         # characters (digits or letters).
         result = exporter.extractLikelyDateText("code1234:56end")
         assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# waitForDialog / closeDialog
+# ---------------------------------------------------------------------------
+
+
+class FakeDialogLocator:
+    def __init__(self, visible: bool):
+        self.visible = visible
+        self.last = self
+        self.timeouts = []
+
+    def is_visible(self, timeout=None):
+        self.timeouts.append(timeout)
+        return self.visible
+
+
+class FakeControlLocator:
+    def __init__(self, visible: bool):
+        self.visible = visible
+        self.first = self
+        self.clicked = False
+        self.timeouts = []
+
+    def is_visible(self, timeout=None):
+        self.timeouts.append(timeout)
+        return self.visible
+
+    def click(self, timeout=None):
+        self.clicked = True
+
+
+class FakePage:
+    def __init__(self, locator_map):
+        self.locator_map = locator_map
+        self.waits = []
+        self.escape_presses = []
+        self.keyboard = self
+
+    def locator(self, selector):
+        return self.locator_map[selector]
+
+    def wait_for_timeout(self, timeout):
+        self.waits.append(timeout)
+
+    def press(self, key):
+        self.escape_presses.append(key)
+
+
+class TestDialogHandling:
+    def test_wait_for_dialog_returns_visible_fallback_selector(self):
+        selectors = _make_exporter().selectors
+        visible_selector = '[data-testid="drawer"]'
+        locator_map = {
+            selector: FakeDialogLocator(selector == visible_selector)
+            for selector in selectors.iterDialogSelectors()
+        }
+        page = FakePage(locator_map)
+        exporter = _make_exporter(timeoutMs=10)
+
+        dialog = exporter.waitForDialog(page)
+
+        assert dialog is locator_map[visible_selector]
+        assert locator_map[visible_selector].timeouts
+        assert all(
+            timeout is not None and 0 < timeout <= 1000
+            for timeout in locator_map[visible_selector].timeouts
+        )
+
+    def test_close_dialog_uses_back_button_when_close_unavailable(self):
+        exporter = _make_exporter()
+        locator_map = {
+            'button[aria-label="Close"]': FakeControlLocator(False),
+            '[role="button"][aria-label="Close"]': FakeControlLocator(False),
+            'button[aria-label="Back"]': FakeControlLocator(True),
+            '[role="button"][aria-label="Back"]': FakeControlLocator(False),
+        }
+        page = FakePage(locator_map)
+
+        exporter.closeDialog(page, dialog=None)
+
+        assert locator_map['button[aria-label="Back"]'].clicked is True
+        assert page.escape_presses == []

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 
 import pytest
 
 from attendanceConfig import MonthWindow, RuntimeConfig
 import whatsappAttendance
-from whatsappAttendance import AttendanceExporter, PollRecord
+from whatsappAttendance import AttendanceExporter, PollRecord, PollTarget
 
 from datetime import date
 
@@ -372,10 +373,71 @@ class TestLoggerInitialisation:
                 )
                 == 1
             )
+            assert logger.handlers[0].stream is sys.stdout
         finally:
             logger.handlers.clear()
             logger.handlers.extend(old_handlers)
             logger.setLevel(old_level)
+
+
+class FakePollButtonLocator:
+    def __init__(self, name: str):
+        self.name = name
+        self.first = self
+        self.clicked = False
+        self.scrolled = False
+        self.filtered_by = []
+
+    def filter(self, has_text=None):
+        self.filtered_by.append(has_text)
+        return self
+
+    def scroll_into_view_if_needed(self, timeout=None):
+        self.scrolled = True
+
+    def click(self, timeout=None):
+        self.clicked = True
+
+
+class FakePollPage:
+    def __init__(self, locator_map):
+        self.locator_map = locator_map
+        self.requested_selectors = []
+
+    def locator(self, selector):
+        self.requested_selectors.append(selector)
+        return self.locator_map.setdefault(selector, FakePollButtonLocator(selector))
+
+
+class TestPollTargetOpening:
+    def test_build_poll_button_selector_prefers_message_test_id(self):
+        exporter = _make_exporter()
+        target = PollTarget(
+            selector='div:has-text("View votes")',
+            sourceText="Training\nView votes",
+            messageTestId="conv-msg-123",
+        )
+
+        assert exporter.buildPollButtonSelector(target) == (
+            '[data-testid="conv-msg-123"] [data-testid="poll-view-votes"]'
+        )
+
+    def test_open_poll_target_uses_stable_message_selector_when_available(self):
+        exporter = _make_exporter()
+        target = PollTarget(
+            selector='div:has-text("View votes")',
+            sourceText="Training\nView votes",
+            messageTestId="conv-msg-123",
+        )
+        stable_selector = exporter.buildPollButtonSelector(target)
+        stable_locator = FakePollButtonLocator(stable_selector)
+        page = FakePollPage({stable_selector: stable_locator})
+
+        exporter.openPollTarget(page, target)
+
+        assert page.requested_selectors[0] == stable_selector
+        assert stable_locator.scrolled is True
+        assert stable_locator.clicked is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -308,6 +308,61 @@ class TestExtractLikelyDateText:
 
 
 # ---------------------------------------------------------------------------
+# extractPollSummaryText / extractMessageTestId
+# ---------------------------------------------------------------------------
+
+
+class TestPollTargetHelpers:
+    class FakeMessageContainer:
+        def __init__(self, test_id: str | None):
+            self.test_id = test_id
+            self.first = self
+
+        def get_attribute(self, name):
+            assert name == "data-testid"
+            return self.test_id
+
+    class FakePollLocator:
+        def __init__(self, test_id: str | None = None, should_raise: bool = False):
+            self.test_id = test_id
+            self.should_raise = should_raise
+
+        def locator(self, selector):
+            assert selector.startswith("xpath=ancestor-or-self::*")
+            if self.should_raise:
+                raise RuntimeError("no ancestor")
+            return TestPollTargetHelpers.FakeMessageContainer(self.test_id)
+
+    def test_extract_poll_summary_text_returns_first_non_empty_line(self):
+        exporter = _make_exporter()
+
+        assert (
+            exporter.extractPollSummaryText("\n  \nTraining Night\nView votes")
+            == "Training Night"
+        )
+
+    def test_extract_poll_summary_text_returns_empty_string_when_no_content(self):
+        exporter = _make_exporter()
+
+        assert exporter.extractPollSummaryText("\n   \n") == ""
+        assert exporter.extractPollSummaryText("") == ""
+
+    def test_extract_message_test_id_returns_value_when_present(self):
+        exporter = _make_exporter()
+        locator = self.FakePollLocator(test_id="conv-msg-123")
+
+        assert exporter.extractMessageTestId(locator) == "conv-msg-123"
+
+    def test_extract_message_test_id_returns_empty_string_on_failure(self):
+        exporter = _make_exporter()
+
+        assert exporter.extractMessageTestId(self.FakePollLocator(test_id=None)) == ""
+        assert (
+            exporter.extractMessageTestId(self.FakePollLocator(should_raise=True)) == ""
+        )
+
+
+# ---------------------------------------------------------------------------
 # logger initialisation
 # ---------------------------------------------------------------------------
 

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -544,7 +544,7 @@ class TestFindPollCards:
         def locator(self, selector):
             return self.selector_map[selector]
 
-    def test_logs_progress_during_large_poll_candidate_scan(self, monkeypatch):
+    def test_logs_progress_for_large_poll_scan(self, monkeypatch):
         exporter = _make_exporter()
         exporter.logger = self.StubLogger()
         monkeypatch.setattr(exporter, "extractMessageTestId", lambda locator: "")
@@ -573,11 +573,6 @@ class TestFindPollCards:
         )
         assert any(
             "processed 50/60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
-            in message
-            for message in exporter.logger.messages
-        )
-        assert any(
-            "processed 60/60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
             in message
             for message in exporter.logger.messages
         )

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -314,24 +314,26 @@ class TestExtractLikelyDateText:
 
 class TestPollTargetHelpers:
     class FakeMessageContainer:
-        def __init__(self, test_id: str | None):
-            self.test_id = test_id
+        def __init__(self, messageTestId: str | None):
+            self.messageTestId = messageTestId
             self.first = self
 
         def get_attribute(self, name):
             assert name == "data-testid"
-            return self.test_id
+            return self.messageTestId
 
     class FakePollLocator:
-        def __init__(self, test_id: str | None = None, should_raise: bool = False):
-            self.test_id = test_id
+        def __init__(
+            self, messageTestId: str | None = None, should_raise: bool = False
+        ):
+            self.messageTestId = messageTestId
             self.should_raise = should_raise
 
         def locator(self, selector):
             assert selector.startswith("xpath=ancestor-or-self::*")
             if self.should_raise:
                 raise RuntimeError("no ancestor")
-            return TestPollTargetHelpers.FakeMessageContainer(self.test_id)
+            return TestPollTargetHelpers.FakeMessageContainer(self.messageTestId)
 
     def test_extract_poll_summary_text_returns_first_non_empty_line(self):
         exporter = _make_exporter()
@@ -349,14 +351,17 @@ class TestPollTargetHelpers:
 
     def test_extract_message_test_id_returns_value_when_present(self):
         exporter = _make_exporter()
-        locator = self.FakePollLocator(test_id="conv-msg-123")
+        locator = self.FakePollLocator(messageTestId="conv-msg-123")
 
         assert exporter.extractMessageTestId(locator) == "conv-msg-123"
 
     def test_extract_message_test_id_returns_empty_string_on_failure(self):
         exporter = _make_exporter()
 
-        assert exporter.extractMessageTestId(self.FakePollLocator(test_id=None)) == ""
+        assert (
+            exporter.extractMessageTestId(self.FakePollLocator(messageTestId=None))
+            == ""
+        )
         assert (
             exporter.extractMessageTestId(self.FakePollLocator(should_raise=True)) == ""
         )
@@ -432,6 +437,15 @@ class TestLoggerInitialisation:
             result.info("stdout check")
             captured = capsys.readouterr()
             assert "stdout check" in captured.out
+            result_again = whatsappAttendance.getLogger(logger_name)
+            assert result_again is logger
+            assert (
+                sum(
+                    isinstance(handler, logging.StreamHandler)
+                    for handler in logger.handlers
+                )
+                == 1
+            )
         finally:
             logger.handlers.clear()
             logger.handlers.extend(old_handlers)
@@ -511,7 +525,9 @@ class TestPollTargetOpening:
         generic_locator = self.FakePollButtonLocator(target.selector, should_fail=True)
         page = self.FakePollPage({target.selector: generic_locator})
 
-        with pytest.raises(RuntimeError, match="scroll failed"):
+        with pytest.raises(
+            RuntimeError, match="failed to interact with poll vote button"
+        ):
             exporter.openPollTarget(page, target)
 
 

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -382,21 +382,26 @@ class TestLoggerInitialisation:
 
 class TestPollTargetOpening:
     class FakePollButtonLocator:
-        def __init__(self, name: str):
+        def __init__(self, name: str, should_fail: bool = False):
             self.name = name
             self.first = self
             self.clicked = False
             self.scrolled = False
             self.filtered_by = []
+            self.should_fail = should_fail
 
         def filter(self, has_text=None):
             self.filtered_by.append(has_text)
             return self
 
         def scroll_into_view_if_needed(self, timeout=None):
+            if self.should_fail:
+                raise RuntimeError(f"scroll failed for {self.name}")
             self.scrolled = True
 
         def click(self, timeout=None):
+            if self.should_fail:
+                raise RuntimeError(f"click failed for {self.name}")
             self.clicked = True
 
     class FakePollPage:
@@ -438,6 +443,18 @@ class TestPollTargetOpening:
         assert page.requested_selectors[0] == stable_selector
         assert stable_locator.scrolled is True
         assert stable_locator.clicked is True
+
+    def test_open_poll_target_raises_last_error_when_all_candidates_fail(self):
+        exporter = _make_exporter()
+        target = PollTarget(
+            selector='div:has-text("View votes")',
+            sourceText="Training\nView votes",
+        )
+        generic_locator = self.FakePollButtonLocator(target.selector, should_fail=True)
+        page = self.FakePollPage({target.selector: generic_locator})
+
+        with pytest.raises(RuntimeError, match="scroll failed"):
+            exporter.openPollTarget(page, target)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -262,21 +262,6 @@ class TestCleanVoterNames:
 
 
 # ---------------------------------------------------------------------------
-# DryRunMixin.prefix
-# ---------------------------------------------------------------------------
-
-
-class TestDryRunPrefix:
-    def test_prefix_when_dry_run_true(self):
-        exporter = _make_exporter(dryRun=True)
-        assert exporter.prefix == "[] "
-
-    def test_prefix_when_dry_run_false(self):
-        exporter = _make_exporter(dryRun=False)
-        assert exporter.prefix == ""
-
-
-# ---------------------------------------------------------------------------
 # extractLikelyDateText
 # ---------------------------------------------------------------------------
 

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -371,9 +371,7 @@ class TestPollTargetHelpers:
 
 
 class TestLoggerInitialisation:
-    def test_uses_log_utils_logger_with_console_enabled_when_supported(
-        self, monkeypatch
-    ):
+    def test_uses_log_utils_logger_with_console_enabled(self, monkeypatch):
         captured = {}
 
         def fake_get_logger(name, **kwargs):

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -508,6 +508,86 @@ class TestPollTargetOpening:
 
 
 # ---------------------------------------------------------------------------
+# findPollCards
+# ---------------------------------------------------------------------------
+
+
+class TestFindPollCards:
+    class FakeLogger:
+        def __init__(self):
+            self.messages = []
+
+        def info(self, message, *args):
+            self.messages.append(message % args if args else message)
+
+    class FakePollItem:
+        def __init__(self, text: str):
+            self.text = text
+
+        def inner_text(self, timeout=None):
+            return self.text
+
+    class FakePollCollection:
+        def __init__(self, texts):
+            self.texts = list(texts)
+
+        def count(self):
+            return len(self.texts)
+
+        def nth(self, index):
+            return TestFindPollCards.FakePollItem(self.texts[index])
+
+    class FakePollPage:
+        def __init__(self, selector_map):
+            self.selector_map = selector_map
+
+        def locator(self, selector):
+            return self.selector_map[selector]
+
+    def test_logs_progress_during_large_poll_candidate_scan(self, monkeypatch):
+        exporter = _make_exporter()
+        exporter.logger = self.FakeLogger()
+        monkeypatch.setattr(exporter, "extractMessageTestId", lambda locator: "")
+
+        selector_map = {
+            '[data-testid="poll-view-votes"]': self.FakePollCollection([]),
+            'div[role="button"]:has-text("View votes")': self.FakePollCollection([]),
+            'div:has-text("View votes")': self.FakePollCollection(
+                [f"Training {index}" for index in range(60)]
+            ),
+        }
+        page = self.FakePollPage(selector_map)
+
+        result = exporter.findPollCards(page)
+
+        assert len(result) == 60
+        assert any(
+            "scanning 60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
+            in message
+            for message in exporter.logger.messages
+        )
+        assert any(
+            "processed 25/60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
+            in message
+            for message in exporter.logger.messages
+        )
+        assert any(
+            "processed 50/60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
+            in message
+            for message in exporter.logger.messages
+        )
+        assert any(
+            "processed 60/60 poll candidate(s) for selector 'div:has-text(\"View votes\")'"
+            in message
+            for message in exporter.logger.messages
+        )
+        assert any(
+            "poll discovery complete: 60 unique poll target(s)" in message
+            for message in exporter.logger.messages
+        )
+
+
+# ---------------------------------------------------------------------------
 # waitForDialog / closeDialog
 # ---------------------------------------------------------------------------
 

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -547,6 +547,7 @@ class TestFindPollCards:
     def test_logs_progress_for_large_poll_scan(self, monkeypatch):
         exporter = _make_exporter()
         exporter.logger = self.StubLogger()
+        # Keep keys text-based so this test focuses only on scan progress logging.
         monkeypatch.setattr(exporter, "extractMessageTestId", lambda locator: "")
 
         selector_map = {

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-import sys
 from pathlib import Path
 
 import pytest
@@ -373,7 +371,7 @@ class TestPollTargetHelpers:
 
 
 class TestLoggerInitialisation:
-    def test_uses_external_logger_with_console_enabled_when_supported(
+    def test_uses_log_utils_logger_with_console_enabled_when_supported(
         self, monkeypatch
     ):
         captured = {}
@@ -393,13 +391,12 @@ class TestLoggerInitialisation:
             "kwargs": {"includeConsole": True, "dryRun": True},
         }
 
-    def test_retries_external_logger_when_kwargs_not_supported(self, monkeypatch):
-        calls = []
+    def test_passes_dry_run_state_to_log_utils(self, monkeypatch):
+        captured = {}
 
         def fake_get_logger(name, **kwargs):
-            calls.append((name, kwargs))
-            if kwargs:
-                raise TypeError("unexpected kwargs")
+            captured["name"] = name
+            captured["kwargs"] = kwargs
             return "logger"
 
         monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", fake_get_logger)
@@ -407,49 +404,10 @@ class TestLoggerInitialisation:
         logger = whatsappAttendance.getLogger("test.logger", dryRun=False)
 
         assert logger == "logger"
-        assert calls == [
-            ("test.logger", {"includeConsole": True, "dryRun": False}),
-            ("test.logger", {"includeConsole": True}),
-            ("test.logger", {}),
-        ]
-
-    def test_stdlib_fallback_adds_stream_handler_once(self, monkeypatch, capsys):
-        monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", None)
-        logger_name = "test.whatsappAttendance.logger"
-        logger = logging.getLogger(logger_name)
-        old_handlers = list(logger.handlers)
-        old_level = logger.level
-        try:
-            logger.handlers.clear()
-
-            result = whatsappAttendance.getLogger(logger_name)
-
-            assert result is logger
-            assert logger.level == logging.INFO
-            assert (
-                sum(
-                    isinstance(handler, logging.StreamHandler)
-                    for handler in logger.handlers
-                )
-                == 1
-            )
-            assert logger.handlers[0].stream is sys.stdout
-            result.info("stdout check")
-            captured = capsys.readouterr()
-            assert "stdout check" in captured.out
-            result_again = whatsappAttendance.getLogger(logger_name)
-            assert result_again is logger
-            assert (
-                sum(
-                    isinstance(handler, logging.StreamHandler)
-                    for handler in logger.handlers
-                )
-                == 1
-            )
-        finally:
-            logger.handlers.clear()
-            logger.handlers.extend(old_handlers)
-            logger.setLevel(old_level)
+        assert captured == {
+            "name": "test.logger",
+            "kwargs": {"includeConsole": True, "dryRun": False},
+        }
 
 
 class TestPollTargetOpening:

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -408,7 +408,7 @@ class TestLoggerInitialisation:
             ("test.logger", {}),
         ]
 
-    def test_stdlib_fallback_adds_stream_handler_once(self, monkeypatch):
+    def test_stdlib_fallback_adds_stream_handler_once(self, monkeypatch, capsys):
         monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", None)
         logger_name = "test.whatsappAttendance.logger"
         logger = logging.getLogger(logger_name)
@@ -429,6 +429,9 @@ class TestLoggerInitialisation:
                 == 1
             )
             assert logger.handlers[0].stream is sys.stdout
+            result.info("stdout check")
+            captured = capsys.readouterr()
+            assert "stdout check" in captured.out
         finally:
             logger.handlers.clear()
             logger.handlers.extend(old_handlers)

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from attendanceConfig import MonthWindow, RuntimeConfig
+import whatsappAttendance
 from whatsappAttendance import AttendanceExporter, PollRecord
 
 from datetime import date
@@ -302,6 +304,78 @@ class TestExtractLikelyDateText:
         # characters (digits or letters).
         result = exporter.extractLikelyDateText("code1234:56end")
         assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# logger initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestLoggerInitialisation:
+    def test_uses_external_logger_with_console_enabled_when_supported(
+        self, monkeypatch
+    ):
+        captured = {}
+
+        def fake_get_logger(name, **kwargs):
+            captured["name"] = name
+            captured["kwargs"] = kwargs
+            return "logger"
+
+        monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", fake_get_logger)
+
+        logger = whatsappAttendance.getLogger("test.logger", dryRun=True)
+
+        assert logger == "logger"
+        assert captured == {
+            "name": "test.logger",
+            "kwargs": {"includeConsole": True, "dryRun": True},
+        }
+
+    def test_retries_external_logger_when_kwargs_not_supported(self, monkeypatch):
+        calls = []
+
+        def fake_get_logger(name, **kwargs):
+            calls.append((name, kwargs))
+            if kwargs:
+                raise TypeError("unexpected kwargs")
+            return "logger"
+
+        monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", fake_get_logger)
+
+        logger = whatsappAttendance.getLogger("test.logger", dryRun=False)
+
+        assert logger == "logger"
+        assert calls == [
+            ("test.logger", {"includeConsole": True, "dryRun": False}),
+            ("test.logger", {"includeConsole": True}),
+            ("test.logger", {}),
+        ]
+
+    def test_stdlib_fallback_adds_stream_handler_once(self, monkeypatch):
+        monkeypatch.setattr(whatsappAttendance, "_logUtilsGetLogger", None)
+        logger_name = "test.whatsappAttendance.logger"
+        logger = logging.getLogger(logger_name)
+        old_handlers = list(logger.handlers)
+        old_level = logger.level
+        try:
+            logger.handlers.clear()
+
+            result = whatsappAttendance.getLogger(logger_name)
+
+            assert result is logger
+            assert logger.level == logging.INFO
+            assert (
+                sum(
+                    isinstance(handler, logging.StreamHandler)
+                    for handler in logger.handlers
+                )
+                == 1
+            )
+        finally:
+            logger.handlers.clear()
+            logger.handlers.extend(old_handlers)
+            logger.setLevel(old_level)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -269,11 +269,11 @@ class TestCleanVoterNames:
 class TestDryRunPrefix:
     def test_prefix_when_dry_run_true(self):
         exporter = _make_exporter(dryRun=True)
-        assert exporter.prefix == "...[] "
+        assert exporter.prefix == "[] "
 
     def test_prefix_when_dry_run_false(self):
         exporter = _make_exporter(dryRun=False)
-        assert exporter.prefix == "..."
+        assert exporter.prefix == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -380,36 +380,36 @@ class TestLoggerInitialisation:
             logger.setLevel(old_level)
 
 
-class FakePollButtonLocator:
-    def __init__(self, name: str):
-        self.name = name
-        self.first = self
-        self.clicked = False
-        self.scrolled = False
-        self.filtered_by = []
-
-    def filter(self, has_text=None):
-        self.filtered_by.append(has_text)
-        return self
-
-    def scroll_into_view_if_needed(self, timeout=None):
-        self.scrolled = True
-
-    def click(self, timeout=None):
-        self.clicked = True
-
-
-class FakePollPage:
-    def __init__(self, locator_map):
-        self.locator_map = locator_map
-        self.requested_selectors = []
-
-    def locator(self, selector):
-        self.requested_selectors.append(selector)
-        return self.locator_map.setdefault(selector, FakePollButtonLocator(selector))
-
-
 class TestPollTargetOpening:
+    class FakePollButtonLocator:
+        def __init__(self, name: str):
+            self.name = name
+            self.first = self
+            self.clicked = False
+            self.scrolled = False
+            self.filtered_by = []
+
+        def filter(self, has_text=None):
+            self.filtered_by.append(has_text)
+            return self
+
+        def scroll_into_view_if_needed(self, timeout=None):
+            self.scrolled = True
+
+        def click(self, timeout=None):
+            self.clicked = True
+
+    class FakePollPage:
+        def __init__(self, locator_map):
+            self.locator_map = locator_map
+            self.requested_selectors = []
+
+        def locator(self, selector):
+            self.requested_selectors.append(selector)
+            return self.locator_map.setdefault(
+                selector, TestPollTargetOpening.FakePollButtonLocator(selector)
+            )
+
     def test_build_poll_button_selector_prefers_message_test_id(self):
         exporter = _make_exporter()
         target = PollTarget(
@@ -430,8 +430,8 @@ class TestPollTargetOpening:
             messageTestId="conv-msg-123",
         )
         stable_selector = exporter.buildPollButtonSelector(target)
-        stable_locator = FakePollButtonLocator(stable_selector)
-        page = FakePollPage({stable_selector: stable_locator})
+        stable_locator = self.FakePollButtonLocator(stable_selector)
+        page = self.FakePollPage({stable_selector: stable_locator})
 
         exporter.openPollTarget(page, target)
 

--- a/tests/testWhatsappAttendance.py
+++ b/tests/testWhatsappAttendance.py
@@ -513,21 +513,21 @@ class TestPollTargetOpening:
 
 
 class TestFindPollCards:
-    class FakeLogger:
+    class StubLogger:
         def __init__(self):
             self.messages = []
 
         def info(self, message, *args):
             self.messages.append(message % args if args else message)
 
-    class FakePollItem:
+    class StubPollItem:
         def __init__(self, text: str):
             self.text = text
 
         def inner_text(self, timeout=None):
             return self.text
 
-    class FakePollCollection:
+    class StubPollCollection:
         def __init__(self, texts):
             self.texts = list(texts)
 
@@ -535,9 +535,9 @@ class TestFindPollCards:
             return len(self.texts)
 
         def nth(self, index):
-            return TestFindPollCards.FakePollItem(self.texts[index])
+            return TestFindPollCards.StubPollItem(self.texts[index])
 
-    class FakePollPage:
+    class StubPollPage:
         def __init__(self, selector_map):
             self.selector_map = selector_map
 
@@ -546,17 +546,17 @@ class TestFindPollCards:
 
     def test_logs_progress_during_large_poll_candidate_scan(self, monkeypatch):
         exporter = _make_exporter()
-        exporter.logger = self.FakeLogger()
+        exporter.logger = self.StubLogger()
         monkeypatch.setattr(exporter, "extractMessageTestId", lambda locator: "")
 
         selector_map = {
-            '[data-testid="poll-view-votes"]': self.FakePollCollection([]),
-            'div[role="button"]:has-text("View votes")': self.FakePollCollection([]),
-            'div:has-text("View votes")': self.FakePollCollection(
+            '[data-testid="poll-view-votes"]': self.StubPollCollection([]),
+            'div[role="button"]:has-text("View votes")': self.StubPollCollection([]),
+            'div:has-text("View votes")': self.StubPollCollection(
                 [f"Training {index}" for index in range(60)]
             ),
         }
-        page = self.FakePollPage(selector_map)
+        page = self.StubPollPage(selector_map)
 
         result = exporter.findPollCards(page)
 


### PR DESCRIPTION
Bootstraps the project with tests, resolves outstanding merge conflicts, fixes a stdlib module name collision, and aligns the CLI with the project's safe-by-default convention.

## Changes Made

- **Merge conflicts resolved**: `README.md` (full structured documentation under the `organiseMyFooty` name) and `.gitignore` (comprehensive Python gitignore).
- **Bug fix — stdlib name collision**: Renamed `src/selectors.py` → `src/whatsappSelectors.py` to prevent shadowing Python's built-in `selectors` module, and updated the import in `whatsappAttendance.py`.
- **`--dry-run` replaced with `--confirm`**: The CLI now defaults to dry-run mode (safe-by-default). Pass `--confirm` to execute the export and write CSV files. `dryRun = not args.confirm` in `exportAttendance.py`.
- **Tests**: Added `tests/conftest.py` (adds `src/` to `sys.path`), `tests/testAttendanceConfig.py` (19 tests), and `tests/testWhatsappAttendance.py` (29 tests) — 48 tests total, all passing.
- **Project-specific Copilot instructions**: Added `.github/additional-copilot-instructions.md` covering source layout, run instructions, testing scope, and key conventions.
- **README**: Updated usage examples and CLI options table to reflect `--confirm`.